### PR TITLE
feat: Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: 🐛 Bug report
+description: Something isn't working as expected.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please provide enough detail so we can reproduce the issue.
+        **Do not include secrets** (tokens, client secrets, Authorization headers).
+
+  - type: checkboxes
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and discussions and didn’t find a duplicate.
+          required: true
+        - label: I'm using the latest released version (or I've confirmed the issue exists on main).
+          required: true
+        - label: I can reproduce this consistently.
+          required: false
+
+  - type: input
+    attributes:
+      label: App/Extension version
+      description: Version number or commit SHA.
+      placeholder: "e.g., v0.6.1 or 1a2b3c4"
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Host environment
+      options:
+        - Power Platform ToolBox (PPTB)
+        - Standalone (web)
+        - Other (please specify below)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Browser (if applicable)
+      placeholder: "e.g., Edge 121 / Chrome 120"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: OS
+      placeholder: "e.g., Windows 11 / macOS 14"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: "Describe what you observed..."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Provide minimal steps to reproduce the issue.
+      placeholder: |
+        1. Open...
+        2. Click...
+        3. Run query...
+        4. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      placeholder: "What should have happened?"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      placeholder: "What actually happened?"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots or recordings (optional)
+      description: Drag and drop images/video here.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Console logs (optional)
+      description: Paste relevant browser/devtools logs (sanitize sensitive info).
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Anything else that might help.
+    validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔐 Security issue (private)
+    url: https://github.com/mohsinonxrm/pptb-mxrm-fetchxml-studio/security/advisories/new
+    about: Please report vulnerabilities privately via GitHub Security Advisories.
+  - name: 🧰 Power Platform ToolBox (PPTB)
+    url: https://www.powerplatformtoolbox.com/
+    about: Info about the PPTB host environment where this tool runs.
+  - name: 📖 FetchXML reference (Microsoft Learn)
+    url: https://learn.microsoft.com/en-us/power-apps/developer/data-platform/fetchxml/overview
+    about: FetchXML query syntax, paging/limits, and guidance.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,30 @@
+name: 📚 Documentation
+description: Report missing/incorrect docs or request a new guide.
+title: "[Docs]: "
+labels: ["docs"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues/discussions for duplicates.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: What is wrong or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Suggested improvement
+      placeholder: "Propose wording, steps, or a new section..."
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Context
+      placeholder: "Link to page/section or screenshot..."
+    validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: ✨ Feature request
+description: Suggest an idea or improvement.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Great feature requests include the **problem**, **who it helps**, and **what success looks like**.
+
+  - type: checkboxes
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues/discussions for duplicates.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: "As a user, I want to..."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+      placeholder: "Add support for..."
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches/workarounds you tried?
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: UX / UI notes (Fluent UI v9)
+      description: Any UI expectations, accessibility concerns, keyboard shortcuts, etc.
+      placeholder: "e.g., CommandBar action, panel layout, copy-to-clipboard behavior..."
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Dataverse considerations (if relevant)
+      description: Tables, metadata, paging, throttling, batch, permissions, etc.
+      placeholder: "e.g., requires $expand, needs paging via @odata.nextLink..."
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: Priority / impact
+      options:
+        - Nice to have
+        - Important
+        - Critical for adoption
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Screenshots, examples, references to FetchXML Builder behavior, etc.
+    validations:

--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -1,0 +1,69 @@
+name: 🐢 Performance issue
+description: Slow UI, slow metadata loading, long query execution, memory spikes, etc.
+title: "[Performance]: "
+labels: ["performance", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Performance reports are most useful with timings + dataset size.
+        🚫 Do NOT include tokens or Authorization headers.
+
+  - type: input
+    attributes:
+      label: Tool version
+      placeholder: "e.g., v0.3.0"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: PPTB version (if known)
+      placeholder: "e.g., 1.0.x"
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: Where is it slow?
+      options:
+        - App startup / loading
+        - Metadata loading (tables/columns/relationships)
+        - Building/editing queries (UI/editor)
+        - Query execution
+        - Rendering results grid
+        - Export
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Rough timing
+      placeholder: "e.g., metadata load ~45s; query ~12s"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Approx dataset size
+      placeholder: "e.g., 300 tables; query returns ~8k rows"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Notes / logs (optional)
+      description: Console logs, screenshots, or network summaries (sanitize).
+    validations:

--- a/.github/ISSUE_TEMPLATE/query_builder_bug.yml
+++ b/.github/ISSUE_TEMPLATE/query_builder_bug.yml
@@ -1,0 +1,134 @@
+name: 🧩 Dataverse / Web API bug
+description: Issues involving Dataverse Web API calls, metadata loading, or query execution.
+title: "[Dataverse Bug]: "
+labels: ["bug", "dataverse", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the issue involves Dataverse Web API (OData), metadata, or query execution.
+        ✅ Include HTTP status + request/correlation IDs if available.
+        🚫 Do NOT paste secrets (tokens, Authorization headers).
+
+        Note: Dataverse can return partial results and requires paging in many scenarios (often a common cause of “missing records”). See FetchXML paging/limits guidance if relevant.
+
+  - type: checkboxes
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I can reproduce consistently.
+          required: false
+        - label: I tested with a different table/query and see similar behavior.
+          required: false
+
+  - type: input
+    attributes:
+      label: Tool version
+      placeholder: "e.g., v0.3.0 or commit SHA"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: PPTB version (if known)
+      placeholder: "e.g., 1.0.x"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Dataverse Web API version (if known)
+      placeholder: "e.g., v9.2"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Environment region (optional)
+      placeholder: "e.g., NA / EU / UK / APAC"
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Affected area
+      description: What part is failing?
+      placeholder: |
+        - Metadata loading (tables/columns/relationships)
+        - Query execution
+        - Results rendering
+        - Export
+        - Other (describe)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Minimal FetchXML snippet
+      description: Provide the smallest query that reproduces (redact identifiers if needed).
+      placeholder: |
+        <fetch top="50">
+          <entity name="account">
+            <attribute name="name" />
+          </entity>
+        </fetch>
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open tool in PPTB
+        2. Select environment
+        3. Paste/build query
+        4. Execute
+        5. Observe error / incorrect behavior
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected vs actual
+      placeholder: |
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: HTTP / error details (recommended)
+      description: Include HTTP status + error payload shown in UI (sanitize).
+      placeholder: |
+        Status: 400
+        Error code: 0x...
+        Message: ...
+        Request/Correlation ID: ...
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Paging / result size notes (optional)
+      description: Mention if you hit row limits, nextLink/paging, or large datasets.
+      placeholder: |
+        - Returns exactly 5000 rows
+        - nextLink present/not present
+        - Very large table / heavy joins
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: Impact
+      options:
+        - Blocking (cannot use tool)
+        - Major (core feature broken)
+        - Minor (workaround exists)
+        - Cosmetic / UI only
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,28 @@
+name: ❓ Question
+description: Ask a question about usage or behavior.
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For questions, include enough context for others to help.
+
+  - type: textarea
+    attributes:
+      label: Question
+      validations:
+        required: true
+
+  - type: textarea
+    attributes:
+      label: What have you tried?
+      validations:
+        required: false
+
+  - type: input
+    attributes:
+      label: Version
+      placeholder: "e.g., v0.6.1"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+What does this PR change and why?
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Build/CI
+
+## How to test
+
+Steps to validate the change.
+
+## Screenshots (if UI)
+
+Before/After images or recordings.
+
+## Checklist
+
+- [ ] Added/updated tests (if applicable)
+- [ ] Updated docs (if applicable)
+- [ ] No secrets included (tokens/keys)
+- [ ] Accessibility considered (keyboard/nav/contrast)

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ dist-ssr
 *.sw?
 
 # Instructions for GitHub Copilot
-.github/*
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue.
+Use GitHub Security Advisories: <https://github.com/mohsinonxrm/pptb-mxrm-fetchxml-studio/security/advisories/new>
+
+## Scope
+
+- Authentication flows
+- Token handling
+- Dataverse request logging
+- Dependency vulnerabilities


### PR DESCRIPTION
- Added various issue templates under .github/ISSUE_TEMPLATE to streamline issue reporting.
- Templates include bug reports, feature requests, performance issues, and more.