### PR TITLE
feat: upgrade @pptb/types to 1.2.0 and adopt host API globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to FetchXML Studio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-23
+
+### ⬆️ Upgraded
+
+- **`@pptb/types` 1.0.7 → 1.2.0** — now the authoritative source for all PPTB host API types (`window.dataverseAPI`, `window.toolboxAPI`). Added to `tsconfig.app.json` `types` array so global augmentations apply project-wide without per-file triple-slash references.
+- **`features.minAPI`** set to `"1.2.0"` in `package.json` to enforce the correct PPTB host version at install time.
+
+### ✨ Added
+
+#### Native File Save Dialog
+- Both export paths (local ExcelJS export and Dataverse `ExportToExcel` action) now use `window.toolboxAPI.fileSystem.saveFile` when running inside the PPTB desktop host, presenting a native OS save-file dialog instead of a forced browser blob download.
+- Graceful fallback to browser blob/anchor download when running in standalone or dev context (i.e. when `window.toolboxAPI` is not available).
+
+#### Connection Environment Awareness
+- `PptbContext` now exposes `environment?: "Dev" | "Test" | "UAT" | "Production"` sourced from the active `DataverseConnection`.
+- Subscribes to `connection:updated`, `connection:created`, and `connection:deleted` PPTB events to keep the field in sync dynamically.
+
+#### Package Manifest Hardening
+- Added top-level `"icon"` field pointing to `icons/icon.svg` (replacing deprecated `configurations.iconUrl`).
+- `"features"` block added: `{ "multiConnection": "none", "minAPI": "1.2.0" }`.
+- `cspExceptions` migrated from plain-string arrays to the required object format with `domain` + `exceptionReason` fields (+ `optional: true` on style-src).
+- Added `"validate": "pptb-validate"` npm script for pre-publish manifest validation.
+- Added `"finalize-package": "npm run build && npm shrinkwrap"` convenience script.
+
+### ♻️ Refactored
+
+#### `pptbClient.ts`
+- Removed the entire hand-written `declare global { interface Window { dataverseAPI?: { ... } } }` block (~60 lines). The `window.dataverseAPI` global is now typed entirely by `@pptb/types`.
+- Added local `DataverseFetchXmlResponse` interface to capture OData response annotations beyond what `@pptb/types` `FetchXmlResult` declares (`@Microsoft.Dynamics.CRM.totalrecordcount`, `morerecords`, `pagingcookie`, `totalrecordcountlimitexceeded`). These are OData wire annotations returned directly by Dataverse — not fabricated by PPTB — so the cast is safe at runtime.
+- `downloadBase64File()` changed from `void` to `async Promise<void>`; uses `fileSystem.saveFile` when available.
+
+#### `usePptbContext.ts`
+- Removed the entire hand-written `declare global { interface Window { toolboxAPI?: { ... } } }` block. The `window.toolboxAPI` global is now typed entirely by `@pptb/types`.
+- `PptbContext` interface: removed legacy `organizationId?: string` (not present in `DataverseConnection` v1.2.0 types); replaced with `environment?: "Dev" | "Test" | "UAT" | "Production"`.
+
+#### `excelExport.ts`
+- `downloadExcelFile()` changed from `void` to `async Promise<void>`; uses `fileSystem.saveFile` when available.
+
+#### `AppShell.tsx`
+- Both download call sites updated with `await` to match the new async signatures.
+
+### 🔧 Technical
+
+- TypeScript strict compile: **zero errors** (`tsc -b --noEmit`).
+- `pptb-validate`: **✔ Validation passed**.
+
+---
+
 ## [1.0.6] - 2026-01-14
 
 ### ✨ Added

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # FetchXML Studio for Power Platform ToolBox
 
-A powerful, modern FetchXML query builder and data explorer for [Power Platform ToolBox](https://github.com/PowerPlatformToolBox/desktop-app). Inspired by the XrmToolBox FetchXML Builder, reimagined with React 19, Fluent UI v9, and seamless Dataverse integration.
+A powerful, modern FetchXML query builder and data explorer for [Power Platform ToolBox](https://github.com/PowerPlatformToolBox/desktop-app). Inspired by the XrmToolBox FetchXML Builder, reimagined with React 18, Fluent UI v9, and seamless Dataverse integration.
 
-![Version](https://img.shields.io/badge/version-1.0.6-blue)
+![Version](https://img.shields.io/badge/version-1.1.0-blue)
 ![React](https://img.shields.io/badge/React-18-61DAFB?logo=react)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript)
 ![Fluent UI](https://img.shields.io/badge/Fluent%20UI-v9-0078D4?logo=microsoft)
+![PPTB Types](https://img.shields.io/badge/%40pptb%2Ftypes-1.2.0-orange)
 
 ## ✨ Features
 
@@ -37,23 +38,35 @@ A powerful, modern FetchXML query builder and data explorer for [Power Platform 
 - **Solution-aware** — Add views to solutions during save
 
 ### 📤 Export & Data Operations
-- **Export to Excel** — Native Excel export with proper data types (numbers, dates, currencies)
-- **Formatted value options** — Export formatted, raw, or both value types
-- **Record deletion** — Delete selected records with confirmation
-- **Bulk delete jobs** — Submit async bulk delete operations to Dataverse
-- **Run workflows** — Execute on-demand workflows on selected records
+- **Local Excel export** — Native `.xlsx` generation via ExcelJS with proper data types (numbers, dates, currencies, booleans)
+- **Dataverse Excel export** — Server-side export via the `ExportToExcel` action (requires a saved view)
+- **Native save dialog** — When running inside PPTB, both export paths use `fileSystem.saveFile` for a native OS save-file dialog; falls back to browser blob download in standalone/dev mode
+- **Formatted value options** — Export formatted values, raw values, or both side-by-side columns
+- **Record deletion** — Delete selected records with confirmation dialog
+- **Bulk delete jobs** — Submit async `BulkDelete` jobs to Dataverse with job-tracking URL
+- **Batch delete** — Parallel per-record delete for small sets (up to 100 records) with progress and ETA
+- **Run workflows** — Execute on-demand workflows on selected records with batch execution and progress tracking
+
+### 📋 Bulk Attribute Selection
+- **Select Attributes dialog** — Multi-select attributes from a searchable DataGrid; accessible from entity and link-entity context menus
+- **Smart updates** — Adds new selections and removes deselected attributes while preserving existing order and properties
+- **Search & filter** — Real-time filtering across logical name, display name, and data type columns
 
 ### 🎨 User Experience
 - **Dark/Light themes** — Follows Power Platform ToolBox theme with Fluent UI tokens
 - **Lazy metadata loading** — Loads only what's needed, when it's needed
-- **Intelligent caching** — In-memory cache prevents duplicate API calls
-- **Resizable panes** — Adjust the layout to your preference
-- **Keyboard shortcuts** — Execute queries, copy XML, and more
+- **Intelligent caching** — In-memory cache prevents duplicate API calls per session
+- **Resizable panes** — Adjust split-pane layout to your preference
+- **Keyboard shortcuts** — `Ctrl+Enter` to execute query, copy XML to clipboard
+- **Display settings** — Toggle logical names vs display names in column headers; choose formatted, raw, or both value modes in the grid and exports
 
 ### 🔒 Privilege-Aware
-- **Security checks** — Validates user privileges before operations
-- **Export privilege check** — Only shows export option if user has access
-- **Delete privilege check** — Validates delete permissions per entity
+- **Security checks** — Validates user privileges before every destructive or restricted operation
+- **Export privilege check** — Only shows Dataverse export option if user has access
+- **Delete privilege check** — Validates entity-specific delete permissions before enabling delete actions
+- **Bulk delete privilege check** — Validates `prvBulkDelete` before surfacing bulk delete
+- **Workflow privilege check** — Validates `prvReadWorkflow` + `prvWorkflowExecution` before showing workflow picker
+- **View save privilege check** — Validates `prvWriteQuery` / `prvWriteCustomization` / `prvPublishCustomization` / `prvWriteUserQuery` before save operations
 
 ## 🖼️ Interface Overview
 
@@ -114,6 +127,12 @@ npm run build
 
 # Preview production build
 npm run preview
+
+# Validate package manifest against PPTB registry rules
+npm run validate
+
+# Finalize for publishing (build + shrinkwrap)
+npm run finalize-package
 ```
 
 ### Debug Logging
@@ -138,48 +157,57 @@ disableAllDebug();
 
 ## 📦 Tech Stack
 
-| Technology | Purpose |
-|------------|---------|
-| **React 19** | UI framework with latest features (transitions, actions) |
-| **TypeScript 5.9** | Type-safe development |
-| **Vite** | Fast build tooling and HMR |
-| **Fluent UI v9** | Microsoft's design system (Tree, DataGrid, Tabs, etc.) |
-| **Monaco Editor** | VS Code's editor for XML editing |
-| **react-window** | Virtualized list rendering for large datasets |
-| **exceljs** | Native Excel file generation |
-| **@pptb/types** | Power Platform ToolBox API types |
+| Technology | Version | Purpose |
+|------------|---------|--------|
+| **React** | 18.3 | UI framework |
+| **TypeScript** | 5.9 | Type-safe development |
+| **Vite** | 7 | Build tooling and HMR |
+| **Fluent UI v9** | 9.72 | Microsoft design system (Tree, DataGrid, Tabs, Drawer, etc.) |
+| **Monaco Editor** | 0.54 | VS Code XML editor for FetchXML authoring |
+| **react-window** | 2 | Virtualized list rendering for large datasets |
+| **ExcelJS** | 4.4 | Native `.xlsx` generation with typed cells |
+| **@pptb/types** | 1.2.0 | Power Platform ToolBox host API types (`window.dataverseAPI`, `window.toolboxAPI`) |
 
 ## 📁 Project Structure
 
 ```
 src/
 ├── app/
-│   └── AppShell.tsx              # Main layout with split panes
+│   └── AppShell.tsx              # Main layout with resizable split panes
 ├── features/fetchxml/
 │   ├── api/
-│   │   ├── pptbClient.ts         # Dataverse API wrapper
-│   │   ├── dataverseMetadata.ts  # Metadata fetching
-│   │   ├── excelExport.ts        # Excel export logic
-│   │   └── formattedValues.ts    # OData formatted value handling
+│   │   ├── pptbClient.ts         # window.dataverseAPI wrapper (all Dataverse ops)
+│   │   ├── dataverseMetadata.ts  # Lazy metadata loading with cache + dedup
+│   │   ├── excelExport.ts        # Local ExcelJS export with native types
+│   │   └── formattedValues.ts    # OData @FormattedValue annotation helpers
 │   ├── model/
-│   │   ├── nodes.ts              # TypeScript node definitions
-│   │   ├── fetchxml.ts           # FetchXML generation
-│   │   ├── fetchxmlParser.ts     # FetchXML parsing
+│   │   ├── nodes.ts              # FetchXML node TypeScript definitions
+│   │   ├── fetchxml.ts           # FetchXML XML generation
+│   │   ├── fetchxmlParser.ts     # FetchXML XML → node tree parser
+│   │   ├── fetchxmlIntellisense.ts # Intellisense / autocomplete helpers
 │   │   ├── layoutxml.ts          # LayoutXML generation
-│   │   └── operators.ts          # Operator definitions by type
+│   │   ├── operators.ts          # Operator definitions by attribute type
+│   │   ├── displaySettings.ts    # Display settings types and defaults
+│   │   └── treeUtils.ts          # Tree traversal utilities
 │   ├── state/
-│   │   ├── builderStore.tsx      # React context state management
-│   │   └── cache.ts              # Metadata caching
+│   │   ├── builderStore.tsx      # React context + reducer state management
+│   │   └── cache.ts              # Per-session in-memory metadata cache
 │   └── ui/
-│       ├── LeftPane/             # Tree view and properties
-│       ├── RightPane/            # Tabs, editor, grid
-│       ├── Toolbar/              # Entity selector, view picker
-│       ├── Dialogs/              # Delete, bulk delete, workflow
-│       └── Settings/             # Display preferences
+│       ├── LeftPane/             # Tree view + context-aware properties panel
+│       │   └── PropertiesPanel/
+│       │       └── editors/      # Node-specific property editors
+│       ├── RightPane/            # Monaco editor, LayoutXML viewer, results grid
+│       ├── Toolbar/              # Entity selector, load view picker, save button
+│       ├── Dialogs/              # Save view, select attributes, delete, bulk
+│       │                         # delete, workflow picker, solution picker
+│       └── Settings/             # Settings drawer (display preferences)
 └── shared/
-    ├── components/               # Reusable pickers
-    ├── hooks/                    # Custom React hooks
-    └── utils/                    # Debug utilities
+    ├── components/               # Reusable value pickers (option set, boolean,
+    │                             # date, numeric, multi-value, relationship, etc.)
+    ├── contexts/                 # ThemeContext
+    ├── hooks/                    # usePptbContext, useLazyMetadata, useAccessMode,
+    │                             # usePublisherFilter, useSolutionFilter
+    └── utils/                    # Debug logging utilities
 ```
 
 ## 🔧 FetchXML Features Support

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mohsinonxrm/pptb-fetchxml-studio",
-	"version": "1.0.5",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mohsinonxrm/pptb-fetchxml-studio",
-			"version": "1.0.5",
+			"version": "1.1.0",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@fluentui-contrib/react-data-grid-react-window": "^1.4.1",
@@ -23,7 +23,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.36.0",
-				"@pptb/types": "^1.0.7",
+				"@pptb/types": "^1.2.0",
 				"@types/node": "^24.10.4",
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.7",
@@ -2870,11 +2870,14 @@
 			}
 		},
 		"node_modules/@pptb/types": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/@pptb/types/-/types-1.0.7.tgz",
-			"integrity": "sha512-NmWmrT8YyppV4LeFk056H8z2ZwoMi8Q3zFs67QZARvCAR+6q0JzMLV91N6+Sdqbd3MvKx1yxqoeePSPi5s8RpQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@pptb/types/-/types-1.2.0.tgz",
+			"integrity": "sha512-0n02+gHiU+T+Rrp0FkX2DHyv3m7LKrraQfV11INWiFvqY5j181ToottLMdbjYborpjsVtoTcfGpM0RpDmfA8Xw==",
 			"dev": true,
-			"license": "GPL-3.0"
+			"license": "GPL-3.0",
+			"bin": {
+				"pptb-validate": "bin/pptb-validate.js"
+			}
 		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-beta.43",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
 	"name": "@mohsinonxrm/pptb-fetchxml-studio",
-	"version": "1.0.6",
+	"version": "1.1.0",
 	"type": "module",
 	"displayName": "FetchXML Studio",
 	"description": "A powerful, modern FetchXML query builder and data explorer for Microsoft Dataverse and Dynamics 365.",
 	"author": "Mohsin On xRM",
 	"main": "index.html",
+	"icon": "icons/icon.svg",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/mohsinonxrm/pptb-mxrm-fetchxml-studio.git"
@@ -34,15 +35,32 @@
 	],
 	"cspExceptions": {
 		"connect-src": [
-			"https://*.dynamics.com",
-			"https://*.crm*.dynamics.com"
+			{
+				"domain": "https://*.dynamics.com",
+				"exceptionReason": "Required to **fetch metadata and records** from Dataverse."
+			},
+			{
+				"domain": "https://*.crm*.dynamics.com",
+				"exceptionReason": "Required to connect to region-specific Dataverse environments."
+			}
 		],
 		"script-src": [
-			"https://cdn.jsdelivr.net"
+			{
+				"domain": "https://cdn.jsdelivr.net",
+				"exceptionReason": "Loads the Monaco XML editor used for FetchXML authoring."
+			}
 		],
 		"style-src": [
-			"https://cdn.jsdelivr.net"
+			{
+				"domain": "https://cdn.jsdelivr.net",
+				"exceptionReason": "Loads Monaco editor bundled styles.",
+				"optional": true
+			}
 		]
+	},
+	"features": {
+		"multiConnection": "none",
+		"minAPI": "1.2.0"
 	},
 	"bugs": {
 		"url": "https://github.com/mohsinonxrm/pptb-mxrm-fetchxml-studio/issues"
@@ -50,7 +68,6 @@
 	"configurations": {
 		"repository": "https://github.com/mohsinonxrm/pptb-mxrm-fetchxml-studio",
 		"website": "https://fetchxml.studio",
-		"iconUrl": "",
 		"readmeUrl": "https://raw.githubusercontent.com/mohsinonxrm/pptb-mxrm-fetchxml-studio/refs/heads/main/README.md"
 	},
 	"files": [
@@ -60,6 +77,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc -b && vite build",
+		"validate": "pptb-validate",
 		"lint": "eslint .",
 		"preview": "vite preview",
 		"finalize-package": "npm run build && npm shrinkwrap"
@@ -79,7 +97,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.36.0",
-		"@pptb/types": "^1.0.7",
+		"@pptb/types": "^1.2.0",
 		"@types/node": "^24.10.4",
 		"@types/react": "^18.3.27",
 		"@types/react-dom": "^18.3.7",

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -211,7 +211,7 @@ export function AppShell() {
  * Includes root entity and all link-entities (recursively)
  */
 function collectEntitiesFromFetchQuery(
-	fetchQuery: import("../features/fetchxml/model/nodes").FetchNode | null
+	fetchQuery: import("../features/fetchxml/model/nodes").FetchNode | null,
 ): string[] {
 	if (!fetchQuery?.entity?.name) return [];
 
@@ -219,7 +219,7 @@ function collectEntitiesFromFetchQuery(
 	entities.add(fetchQuery.entity.name);
 
 	const collectFromLinks = (
-		links: import("../features/fetchxml/model/nodes").LinkEntityNode[] | undefined
+		links: import("../features/fetchxml/model/nodes").LinkEntityNode[] | undefined,
 	) => {
 		links?.forEach((link) => {
 			if (link.name) {
@@ -536,7 +536,7 @@ function AppContent() {
 					console.error(`Failed to load attributes for ${entityName}:`, error);
 					return { entityName, attrMap: new Map<string, AttributeMetadata>() };
 				}
-			})
+			}),
 		).then((results) => {
 			const multiEntityMap = new Map<string, Map<string, AttributeMetadata>>();
 			results.forEach(({ entityName, attrMap }) => {
@@ -646,7 +646,7 @@ function AppContent() {
 	const handleSaveViewComplete = (
 		viewId: string,
 		viewType: "system" | "personal",
-		viewName: string
+		viewName: string,
 	) => {
 		// Update the builder's loaded view state so subsequent saves overwrite the same view
 		if (entityMetadata) {
@@ -666,7 +666,7 @@ function AppContent() {
 	 */
 	const buildColumnsFromResult = (
 		records: Record<string, unknown>[],
-		fetchQuery: typeof builder.fetchQuery
+		fetchQuery: typeof builder.fetchQuery,
 	): string[] => {
 		// Start with columns from the result data (these have actual values)
 		const resultKeys = records.length > 0 ? Object.keys(records[0]) : [];
@@ -743,7 +743,7 @@ function AppContent() {
 					console.log(
 						`📋 Executing ${loadedView.type} view "${loadedView.name}" via ${
 							loadedView.type === "system" ? "savedQuery" : "userQuery"
-						}=${loadedView.id}`
+						}=${loadedView.id}`,
 					);
 
 					if (loadedView.type === "system") {
@@ -759,7 +759,7 @@ function AppContent() {
 				console.log(
 					loadedView
 						? `📝 View "${loadedView.name}" was modified - executing via fetchXmlQuery`
-						: "📡 Executing FetchXML query"
+						: "📡 Executing FetchXML query",
 				);
 				result = await executeFetchXml(fetchXml);
 			}
@@ -800,7 +800,7 @@ function AppContent() {
 					result.pagingCookie,
 					2,
 					entityLogicalName,
-					pageSize
+					pageSize,
 				);
 			}
 		} catch (error) {
@@ -821,7 +821,7 @@ function AppContent() {
 		pagingCookie: string | undefined,
 		startPage: number,
 		entityLogicalName: string | undefined,
-		pageSize?: number
+		pageSize?: number,
 	) => {
 		let allRows = [...initialRows];
 		let currentPagingCookie = pagingCookie;
@@ -839,7 +839,7 @@ function AppContent() {
 					baseFetchXml,
 					page,
 					currentPagingCookie,
-					pageSize
+					pageSize,
 				);
 				const result = await executeFetchXml(pagedFetchXml);
 
@@ -898,7 +898,7 @@ function AppContent() {
 		try {
 			const nextPage = pagingState.currentPage + 1;
 			console.log(
-				`📄 Loading page ${nextPage}${pagingState.pagingCookie ? " with paging cookie" : ""}...`
+				`📄 Loading page ${nextPage}${pagingState.pagingCookie ? " with paging cookie" : ""}...`,
 			);
 
 			// Add paging parameters: page number, paging cookie (required for reliable paging), and count (page size)
@@ -906,7 +906,7 @@ function AppContent() {
 				fetchXml,
 				nextPage,
 				pagingState.pagingCookie,
-				pageSize
+				pageSize,
 			);
 			const result = await executeFetchXml(pagedFetchXml);
 
@@ -977,7 +977,7 @@ function AppContent() {
 
 		try {
 			console.log(
-				`📤 Exporting to Excel via ${builder.loadedView.type} view "${builder.loadedView.name}"...`
+				`📤 Exporting to Excel via ${builder.loadedView.type} view "${builder.loadedView.name}"...`,
 			);
 
 			// Use view name for filename
@@ -988,11 +988,11 @@ function AppContent() {
 				builder.loadedView.type,
 				fetchXml,
 				layoutXml,
-				viewName
+				viewName,
 			);
 
 			// Trigger download
-			downloadBase64File(result.excelFile, result.filename);
+			await downloadBase64File(result.excelFile, result.filename);
 
 			console.log(`✅ Export complete: ${result.filename}`);
 
@@ -1084,7 +1084,7 @@ function AppContent() {
 			});
 
 			// Trigger download
-			downloadExcelFile(buffer, finalFileName);
+			await downloadExcelFile(buffer, finalFileName);
 
 			console.log(`✅ Local export complete: ${finalFileName}`);
 
@@ -1147,7 +1147,7 @@ function AppContent() {
 				window.open(url, "_blank");
 			}
 		},
-		[entityLogicalName]
+		[entityLogicalName],
 	);
 
 	/**
@@ -1173,7 +1173,7 @@ function AppContent() {
 				console.error("Failed to copy to clipboard:", error);
 			}
 		},
-		[entityLogicalName]
+		[entityLogicalName],
 	);
 
 	/**
@@ -1217,15 +1217,15 @@ function AppContent() {
 			const recordName =
 				recordIds.length === 1
 					? (queryResult?.rows.find(
-							(row) => row[entityMetadata?.PrimaryIdAttribute || ""] === recordIds[0]
-					  )?.[entityMetadata?.PrimaryNameAttribute || ""] as string | undefined)
+							(row) => row[entityMetadata?.PrimaryIdAttribute || ""] === recordIds[0],
+						)?.[entityMetadata?.PrimaryNameAttribute || ""] as string | undefined)
 					: undefined;
 
 			// Use batch delete for 4+ records (more efficient than sequential)
 			const isBatchDelete = recordIds.length >= 4;
 			setDeleteDialogState({ open: true, recordIds, recordName, isBatchDelete });
 		},
-		[entityLogicalName, recordActionPrivileges.canBulkDelete, queryResult, entityMetadata]
+		[entityLogicalName, recordActionPrivileges.canBulkDelete, queryResult, entityMetadata],
 	);
 
 	/**
@@ -1246,7 +1246,7 @@ function AppContent() {
 				totalViewRecords: isAllRecords ? totalRecords : undefined,
 			});
 		},
-		[entityLogicalName, recordActionPrivileges.canBulkDelete, queryResult]
+		[entityLogicalName, recordActionPrivileges.canBulkDelete, queryResult],
 	);
 
 	/**
@@ -1264,7 +1264,7 @@ function AppContent() {
 			const result = await deleteRecordsBatch(
 				entityLogicalName, // Use logical name, API will pluralize
 				recordIds,
-				(progress) => setDeleteProgress(progress)
+				(progress) => setDeleteProgress(progress),
 			);
 
 			if (result.succeeded > 0) {
@@ -1286,7 +1286,7 @@ function AppContent() {
 				successCount++;
 			} catch (error) {
 				errors.push(
-					`Failed to delete ${recordId}: ${error instanceof Error ? error.message : String(error)}`
+					`Failed to delete ${recordId}: ${error instanceof Error ? error.message : String(error)}`,
 				);
 			}
 		}
@@ -1342,7 +1342,7 @@ function AppContent() {
 				entityLogicalName,
 				primaryIdAttribute,
 				recordIds,
-				jobName
+				jobName,
 			);
 
 			console.log(`📤 Bulk delete job submitted: ${result.asyncOperationId}`);
@@ -1354,7 +1354,7 @@ function AppContent() {
 			bulkDeleteDialogState.recordIds,
 			bulkDeleteDialogState.isAllRecords,
 			builder.fetchQuery,
-		]
+		],
 	);
 
 	/**
@@ -1382,14 +1382,14 @@ function AppContent() {
 		async (
 			workflowId: string,
 			recordIds: string[],
-			onProgress: (progress: WorkflowBatchProgress) => void
+			onProgress: (progress: WorkflowBatchProgress) => void,
 		): Promise<{ succeeded: number; failed: number; errors: string[] }> => {
 			if (!entityLogicalName) {
 				return { succeeded: 0, failed: recordIds.length, errors: ["Entity not selected"] };
 			}
 			return executeWorkflowBatch(workflowId, recordIds, entityLogicalName, onProgress);
 		},
-		[entityLogicalName]
+		[entityLogicalName],
 	);
 
 	// ============ END RECORD ACTION HANDLERS ============
@@ -1415,7 +1415,7 @@ function AppContent() {
 									entitySetName: viewInfo.entitySetName,
 									name: viewInfo.name,
 								},
-								viewInfo.layoutxml
+								viewInfo.layoutxml,
 							);
 						}}
 					/>
@@ -1495,8 +1495,8 @@ function AppContent() {
 						!builder.loadedView
 							? "Save as a view first to enable export"
 							: !exportStatus.hasPrivilege
-							? "You don't have the prvExportToExcel privilege"
-							: undefined
+								? "You don't have the prvExportToExcel privilege"
+								: undefined
 					}
 					onParseToTree={builder.loadFetchXml}
 					attributeMetadata={attributeMetadata}
@@ -1603,7 +1603,7 @@ function AppContent() {
 
 							// Check if link-entity already exists for this relationship
 							const existingLinkEntity = builder.fetchQuery.entity.links.find(
-								(le) => le.from === fromAttr && le.to === toAttr && le.name === relatedEntity
+								(le) => le.from === fromAttr && le.to === toAttr && le.name === relatedEntity,
 							);
 
 							let linkEntityId: string;
@@ -1618,7 +1618,7 @@ function AppContent() {
 									fromAttr,
 									toAttr,
 									linkType,
-									relTypeForBuilder
+									relTypeForBuilder,
 								);
 							}
 
@@ -1649,7 +1649,7 @@ function AppContent() {
 						// FetchXML order-by uses the original attribute name, not the alias
 						if (!entityName && builder.fetchQuery?.entity?.attributes) {
 							const aliasedAttr = builder.fetchQuery.entity.attributes.find(
-								(a) => a.alias === attribute
+								(a) => a.alias === attribute,
 							);
 							if (aliasedAttr) {
 								attribute = aliasedAttr.name;
@@ -1660,7 +1660,7 @@ function AppContent() {
 							attribute,
 							data.direction === "descending",
 							data.isMultiSort,
-							entityName
+							entityName,
 						);
 					}}
 					// Record action handlers

--- a/src/features/fetchxml/api/excelExport.ts
+++ b/src/features/fetchxml/api/excelExport.ts
@@ -30,7 +30,7 @@ interface ExportToExcelLocalOptions {
  * Returns the workbook buffer for download
  */
 export async function exportToExcelLocal(
-	options: ExportToExcelLocalOptions
+	options: ExportToExcelLocalOptions,
 ): Promise<{ buffer: ArrayBuffer; fileName: string }> {
 	const {
 		records,
@@ -156,7 +156,7 @@ export async function exportToExcelLocal(
 		record: Record<string, unknown>,
 		col: string,
 		isRawColumn: boolean,
-		attr: AttributeMetadata | undefined
+		attr: AttributeMetadata | undefined,
 	): unknown => {
 		const rawValue = record[col];
 		const formattedValue = getFormattedValue(record, col);
@@ -300,7 +300,17 @@ export async function exportToExcelLocal(
 /**
  * Trigger browser download of the Excel file
  */
-export function downloadExcelFile(buffer: ArrayBuffer, fileName: string): void {
+export async function downloadExcelFile(buffer: ArrayBuffer, fileName: string): Promise<void> {
+	// Use PPTB fileSystem.saveFile when running in the desktop host (opens native save dialog)
+	if (window.toolboxAPI?.fileSystem?.saveFile) {
+		const saved = await window.toolboxAPI.fileSystem.saveFile(fileName, new Uint8Array(buffer));
+		if (saved) {
+			console.log(`✅ File saved via fileSystem: ${saved}`);
+		}
+		return;
+	}
+
+	// Fallback: browser blob download (standalone / dev context)
 	const blob = new Blob([buffer], {
 		type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 	});

--- a/src/features/fetchxml/api/pptbClient.ts
+++ b/src/features/fetchxml/api/pptbClient.ts
@@ -3,64 +3,18 @@
  * Provides typed interface to window.dataverseAPI exposed by PPTB host
  */
 
-// Extend window interface for PPTB Dataverse API
-declare global {
-	interface Window {
-		dataverseAPI?: {
-			// CRUD operations
-			create: (entitySetName: string, data: Record<string, unknown>) => Promise<{ id: string }>;
-			retrieve: (
-				entitySetName: string,
-				id: string,
-				select?: string[]
-			) => Promise<Record<string, unknown>>;
-			update: (entitySetName: string, id: string, data: Record<string, unknown>) => Promise<void>;
-			delete: (entitySetName: string, id: string) => Promise<void>;
+// NOTE: window.dataverseAPI global types are provided by @pptb/types (see tsconfig.app.json)
 
-			// Query operations
-			fetchXmlQuery: (fetchXml: string) => Promise<{
-				value: Record<string, unknown>[];
-				"@Microsoft.Dynamics.CRM.totalrecordcount"?: number;
-				"@Microsoft.Dynamics.CRM.totalrecordcountlimitexceeded"?: boolean;
-				"@Microsoft.Dynamics.CRM.morerecords"?: boolean;
-				"@Microsoft.Dynamics.CRM.pagingcookie"?: string;
-			}>;
-			retrieveMultiple: (
-				entitySetName: string,
-				query?: string
-			) => Promise<{
-				value: Record<string, unknown>[];
-			}>;
-			queryData: (odataQuery: string) => Promise<{
-				value: Record<string, unknown>[];
-			}>;
-
-			// Metadata operations
-			getEntityMetadata: (
-				entityLogicalName: string,
-				searchByLogicalName?: boolean,
-				selectColumns?: string[]
-			) => Promise<EntityMetadata>;
-			getAllEntitiesMetadata: () => Promise<{ value: EntityMetadata[] }>;
-			getEntityRelatedMetadata: (
-				entityLogicalName: string,
-				relatedPath: string,
-				selectColumns?: string[]
-			) => Promise<{ value: unknown[] }>;
-
-			// Other operations
-			execute: (options: {
-				operationName: string;
-				operationType: "action" | "function";
-				entityName?: string;
-				entityId?: string;
-				parameters?: Record<string, unknown>;
-			}) => Promise<unknown>;
-			getSolutions: (selectColumns?: string[]) => Promise<{ value: unknown[] }>;
-
-			// User context - note: WhoAmI is called via execute({ operationName: 'WhoAmI', operationType: 'function' })
-		};
-	}
+// Extended type for accessing Dataverse OData response annotations beyond what @pptb/types explicitly declares.
+// Dataverse returns these extra annotations on FetchXML responses; we cast to this locally.
+interface DataverseFetchXmlResponse {
+	value: Record<string, unknown>[];
+	"@odata.context"?: string;
+	"@Microsoft.Dynamics.CRM.fetchxmlpagingcookie"?: string;
+	"@Microsoft.Dynamics.CRM.totalrecordcount"?: number;
+	"@Microsoft.Dynamics.CRM.totalrecordcountlimitexceeded"?: boolean;
+	"@Microsoft.Dynamics.CRM.morerecords"?: boolean;
+	"@Microsoft.Dynamics.CRM.pagingcookie"?: string;
 }
 
 import { debugLog } from "../../../shared/utils/debug";
@@ -258,7 +212,10 @@ export async function getEntityMetadata(logicalName: string): Promise<EntityMeta
 		throw new Error("PPTB Dataverse API not available");
 	}
 
-	return await window.dataverseAPI!.getEntityMetadata(logicalName, true);
+	return (await window.dataverseAPI!.getEntityMetadata(
+		logicalName,
+		true,
+	)) as unknown as EntityMetadata;
 }
 
 /**
@@ -266,7 +223,7 @@ export async function getEntityMetadata(logicalName: string): Promise<EntityMeta
  */
 export async function getEntityAttributes(
 	logicalName: string,
-	advancedFindOnly: boolean = true
+	advancedFindOnly: boolean = true,
 ): Promise<AttributeMetadata[]> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -288,7 +245,7 @@ export async function getEntityAttributes(
 
 	debugLog(
 		"metadataAPI",
-		`✅ Attributes retrieved for '${logicalName}': ${attributes.length} attributes`
+		`✅ Attributes retrieved for '${logicalName}': ${attributes.length} attributes`,
 	);
 
 	// Sort alphabetically by display name (fallback to logical name)
@@ -309,7 +266,7 @@ export async function getEntityAttributes(
  */
 export async function getAttributeWithOptionSet(
 	entityLogicalName: string,
-	attributeLogicalName: string
+	attributeLogicalName: string,
 ): Promise<AttributeMetadata> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -342,7 +299,7 @@ export async function getAttributeWithOptionSet(
 		// For non-optionset attributes, return the basic metadata
 		debugLog(
 			"metadataAPI",
-			`⚠️ Attribute '${attributeLogicalName}' is type '${basicAttr.AttributeType}' - no OptionSet available`
+			`⚠️ Attribute '${attributeLogicalName}' is type '${basicAttr.AttributeType}' - no OptionSet available`,
 		);
 		return basicAttr;
 	}
@@ -352,7 +309,7 @@ export async function getAttributeWithOptionSet(
 
 	debugLog(
 		"metadataAPI",
-		`📡 GET Attribute with OptionSet for '${attributeLogicalName}': ${fullQuery}`
+		`📡 GET Attribute with OptionSet for '${attributeLogicalName}': ${fullQuery}`,
 	);
 
 	const fullResult = await window.dataverseAPI!.queryData(fullQuery);
@@ -361,14 +318,14 @@ export async function getAttributeWithOptionSet(
 
 	if (!fullAttr || !fullAttr.LogicalName) {
 		throw new Error(
-			`Failed to retrieve attribute ${attributeLogicalName} with OptionSet expansion`
+			`Failed to retrieve attribute ${attributeLogicalName} with OptionSet expansion`,
 		);
 	}
 
 	debugLog(
 		"metadataAPI",
 		`✅ Attribute with OptionSet retrieved for '${attributeLogicalName}':`,
-		fullAttr.OptionSet
+		fullAttr.OptionSet,
 	);
 
 	return fullAttr;
@@ -382,7 +339,7 @@ export async function getAttributeWithOptionSet(
 export async function getAttributeDetailedMetadata(
 	entityLogicalName: string,
 	attributeLogicalName: string,
-	attributeType: string
+	attributeType: string,
 ): Promise<AttributeMetadata> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -420,7 +377,7 @@ export async function getAttributeDetailedMetadata(
 			// For types that don't need detailed metadata, return early with warning
 			debugLog(
 				"metadataAPI",
-				`⚠️ Attribute '${attributeLogicalName}' is type '${attributeType}' - no detailed metadata needed`
+				`⚠️ Attribute '${attributeLogicalName}' is type '${attributeType}' - no detailed metadata needed`,
 			);
 			// Return basic metadata query without type cast
 			const basicQuery = `EntityDefinitions(LogicalName='${entityLogicalName}')/Attributes(LogicalName='${attributeLogicalName}')?$select=SchemaName,LogicalName,DisplayName,AttributeType,MetadataId`;
@@ -434,7 +391,7 @@ export async function getAttributeDetailedMetadata(
 
 	debugLog(
 		"metadataAPI",
-		`📡 GET Detailed Attribute metadata for '${attributeLogicalName}' (${attributeType}): ${detailedQuery}`
+		`📡 GET Detailed Attribute metadata for '${attributeLogicalName}' (${attributeType}): ${detailedQuery}`,
 	);
 
 	const result = await window.dataverseAPI!.queryData(detailedQuery);
@@ -452,7 +409,7 @@ export async function getAttributeDetailedMetadata(
 	debugLog(
 		"metadataAPI",
 		`✅ Detailed attribute metadata retrieved for '${attributeLogicalName}':`,
-		detailedAttr
+		detailedAttr,
 	);
 
 	return detailedAttr;
@@ -463,7 +420,7 @@ export async function getAttributeDetailedMetadata(
  */
 export async function getEntityRelationships(
 	logicalName: string,
-	advancedFindOnly: boolean = true
+	advancedFindOnly: boolean = true,
 ): Promise<{
 	oneToMany: RelationshipMetadata[];
 	manyToOne: RelationshipMetadata[];
@@ -512,7 +469,7 @@ export async function getEntityRelationships(
 
 	debugLog(
 		"metadataAPI",
-		`✅ Relationships retrieved for '${logicalName}': 1:N=${oneToManyResult.value.length}, N:1=${manyToOneResult.value.length}, N:N=${manyToManyResult.value.length}`
+		`✅ Relationships retrieved for '${logicalName}': 1:N=${oneToManyResult.value.length}, N:1=${manyToOneResult.value.length}, N:N=${manyToManyResult.value.length}`,
 	);
 
 	// Helper function to sort relationships alphabetically by SchemaName
@@ -542,7 +499,9 @@ export async function executeFetchXml(fetchXml: string): Promise<FetchXmlResult>
 	debugLog("fetchXmlAPI", `📡 Executing FetchXML query...`);
 	debugLog("fetchXmlAPI", `FetchXML:\n${fetchXml}`);
 
-	const result = await window.dataverseAPI!.fetchXmlQuery(fetchXml);
+	const result = (await window.dataverseAPI!.fetchXmlQuery(
+		fetchXml,
+	)) as unknown as DataverseFetchXmlResponse;
 
 	// Log the raw response to console for inspection
 	console.log("🔍 Raw FetchXML Response:", result);
@@ -565,16 +524,16 @@ export async function executeFetchXml(fetchXml: string): Promise<FetchXmlResult>
 		console.warn("🔧 In dataverseManager.ts (around line 405), change:");
 		console.warn('   FROM: Prefer: "return=representation"');
 		console.warn(
-			'   TO:   Prefer: "return=representation, odata.include-annotations=\\"OData.Community.Display.V1.FormattedValue\\""'
+			'   TO:   Prefer: "return=representation, odata.include-annotations=\\"OData.Community.Display.V1.FormattedValue\\""',
 		);
 		console.warn("");
 		console.warn("📖 Microsoft Learn reference:");
 		console.warn(
-			"   https://learn.microsoft.com/en-us/power-apps/developer/data-platform/fetchxml/select-columns?tabs=webapi#formatted-values"
+			"   https://learn.microsoft.com/en-us/power-apps/developer/data-platform/fetchxml/select-columns?tabs=webapi#formatted-values",
 		);
 		console.warn("");
 		console.warn(
-			"💡 This will enable rich display: labels for picklists, names for lookups, formatted dates, etc."
+			"💡 This will enable rich display: labels for picklists, names for lookups, formatted dates, etc.",
 		);
 	}
 
@@ -596,7 +555,7 @@ export async function executeFetchXml(fetchXml: string): Promise<FetchXmlResult>
  */
 export async function executeSystemView(
 	entitySetName: string,
-	savedQueryId: string
+	savedQueryId: string,
 ): Promise<FetchXmlResult> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -627,7 +586,7 @@ export async function executeSystemView(
  */
 export async function executePersonalView(
 	entitySetName: string,
-	userQueryId: string
+	userQueryId: string,
 ): Promise<FetchXmlResult> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -665,7 +624,7 @@ export async function whoAmI(): Promise<WhoAmIResponse | null> {
 		const result = (await window.dataverseAPI!.execute({
 			operationName: "WhoAmI",
 			operationType: "function",
-		})) as WhoAmIResponse;
+		})) as unknown as WhoAmIResponse;
 		return result;
 	} catch (error) {
 		console.error("WhoAmI failed:", error);
@@ -678,7 +637,7 @@ export async function whoAmI(): Promise<WhoAmIResponse | null> {
  */
 export async function checkPrivilegeByName(
 	userId: string,
-	privilegeName: string
+	privilegeName: string,
 ): Promise<boolean> {
 	if (!isDataverseAvailable()) {
 		return false;
@@ -696,7 +655,7 @@ export async function checkPrivilegeByName(
 
 		const hasPrivilege = !!response?.RolePrivileges?.length;
 		console.log(
-			`✅ checkPrivilegeByName(${privilegeName}): ${hasPrivilege ? "GRANTED" : "DENIED"}`
+			`✅ checkPrivilegeByName(${privilegeName}): ${hasPrivilege ? "GRANTED" : "DENIED"}`,
 		);
 
 		return hasPrivilege;
@@ -775,8 +734,8 @@ export async function getPublishersWithSolutions(): Promise<PublisherWithSolutio
 				publishersWithSolutions.length
 			} publishers, ${publishersWithSolutions.reduce(
 				(sum, p) => sum + p.solutions.length,
-				0
-			)} total solutions`
+				0,
+			)} total solutions`,
 		);
 
 		return publishersWithSolutions;
@@ -844,7 +803,7 @@ export async function getSolutionsByPublishers(publisherIds: string[]): Promise<
 				debugLog("solutionAPI", `📡 GET Solutions for publishers: ${chunk.length} IDs`);
 				const result = await window.dataverseAPI!.queryData(query);
 				return result.value as unknown as Solution[];
-			})
+			}),
 		);
 
 		// Flatten and dedupe
@@ -923,7 +882,7 @@ export async function getSolutionComponents(solutionIds: string[]): Promise<Solu
 					components: result.value,
 				});
 				return result.value as unknown as SolutionComponent[];
-			})
+			}),
 		);
 
 		// Flatten and deduplicate by msdyn_name
@@ -951,7 +910,7 @@ export async function getSolutionComponents(solutionIds: string[]): Promise<Solu
 
 		debugLog(
 			"solutionComponentAPI",
-			`✅ Components retrieved: ${components.length} unique entities`
+			`✅ Components retrieved: ${components.length} unique entities`,
 		);
 		return components;
 	} catch (error) {
@@ -1031,7 +990,7 @@ export function filterCachedEntitiesByNames(logicalNames: string[]): EntityMetad
  * Get EntityDefinitions filtered by logical names and IsValidForAdvancedFind
  */
 export async function getAdvancedFindEntitiesByNames(
-	logicalNames: string[]
+	logicalNames: string[],
 ): Promise<EntityMetadata[]> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -1039,7 +998,7 @@ export async function getAdvancedFindEntitiesByNames(
 
 	if (!logicalNames.length) {
 		console.log(
-			"[API] getAdvancedFindEntitiesByNames - Empty logical names, returning all AF entities"
+			"[API] getAdvancedFindEntitiesByNames - Empty logical names, returning all AF entities",
 		);
 		// Return all AF-valid entities
 		return getAllEntities(true);
@@ -1076,7 +1035,7 @@ export async function getAdvancedFindEntitiesByNames(
 					returnedEntities: entities.map((e) => e.LogicalName),
 				});
 				return entities;
-			})
+			}),
 		);
 
 		// Flatten and dedupe
@@ -1230,7 +1189,7 @@ export function generateLayoutXml(
 	columns: LayoutColumn[],
 	objectTypeCode: number,
 	primaryIdAttribute: string,
-	jumpAttribute?: string
+	jumpAttribute?: string,
 ): string {
 	const cellsXml = columns
 		.map((col) => {
@@ -1288,7 +1247,7 @@ export async function getSystemViews(entityLogicalName: string): Promise<SavedVi
 
 		debugLog(
 			"viewAPI",
-			`✅ System Views retrieved for '${entityLogicalName}': ${views.length} views`
+			`✅ System Views retrieved for '${entityLogicalName}': ${views.length} views`,
 		);
 
 		return views;
@@ -1335,14 +1294,14 @@ export async function getPersonalViews(entityLogicalName: string): Promise<Saved
 
 		debugLog(
 			"viewAPI",
-			`✅ Personal Views retrieved for '${entityLogicalName}': ${views.length} views`
+			`✅ Personal Views retrieved for '${entityLogicalName}': ${views.length} views`,
 		);
 
 		return views;
 	} catch (error) {
 		console.error(
 			`getPersonalViews: Failed to get personal views for '${entityLogicalName}':`,
-			error
+			error,
 		);
 		throw error;
 	}
@@ -1353,7 +1312,7 @@ export async function getPersonalViews(entityLogicalName: string): Promise<Saved
  * @param entityLogicalName The logical name of the entity
  */
 export async function getAllViews(
-	entityLogicalName: string
+	entityLogicalName: string,
 ): Promise<{ systemViews: SavedView[]; personalViews: SavedView[] }> {
 	const [systemViews, personalViews] = await Promise.all([
 		getSystemViews(entityLogicalName),
@@ -1399,7 +1358,7 @@ export interface ValidateFetchXmlExpressionResponse {
  * @see https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/validatefetchxmlexpression
  */
 export async function validateFetchXmlExpression(
-	fetchXml: string
+	fetchXml: string,
 ): Promise<ValidateFetchXmlExpressionResponse> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -1414,14 +1373,14 @@ export async function validateFetchXmlExpression(
 		const query = `ValidateFetchXmlExpression(FetchXml=@FetchXml)?@FetchXml='${encodedFetchXml}'`;
 
 		const result = (await window.dataverseAPI!.queryData(
-			query
+			query,
 		)) as unknown as ValidateFetchXmlExpressionResponse;
 
 		debugLog(
 			"viewAPI",
 			`✅ ValidateFetchXmlExpression - Complete: ${
 				result.ValidationResults?.Messages?.length || 0
-			} messages`
+			} messages`,
 		);
 
 		return result;
@@ -1509,7 +1468,7 @@ export async function checkSavedQueryPrivileges(): Promise<{
 
 	debugLog(
 		"viewAPI",
-		`✅ SavedQuery privileges: writeQuery=${canWriteQuery}, writeCustomization=${canWriteCustomization}, publishCustomization=${canPublishCustomization} → canWrite=${canWrite}, canPublish=${canPublish}`
+		`✅ SavedQuery privileges: writeQuery=${canWriteQuery}, writeCustomization=${canWriteCustomization}, publishCustomization=${canPublishCustomization} → canWrite=${canWrite}, canPublish=${canPublish}`,
 	);
 
 	return { canWrite, canPublish };
@@ -1634,7 +1593,7 @@ export async function createSavedQuery(data: CreateSavedQueryData): Promise<stri
  */
 export async function updateSavedQuery(
 	savedQueryId: string,
-	data: Partial<CreateSavedQueryData>
+	data: Partial<CreateSavedQueryData>,
 ): Promise<void> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -1694,7 +1653,7 @@ export async function createUserQuery(data: CreateUserQueryData): Promise<string
  */
 export async function updateUserQuery(
 	userQueryId: string,
-	data: Partial<CreateUserQueryData>
+	data: Partial<CreateUserQueryData>,
 ): Promise<void> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -1726,7 +1685,7 @@ export async function addSolutionComponent(
 	componentId: string,
 	componentType: number,
 	solutionUniqueName: string,
-	addRequiredComponents: boolean = false
+	addRequiredComponents: boolean = false,
 ): Promise<void> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -1734,7 +1693,7 @@ export async function addSolutionComponent(
 
 	debugLog(
 		"viewAPI",
-		`📡 AddSolutionComponent: ${componentId} (type=${componentType}) to "${solutionUniqueName}"`
+		`📡 AddSolutionComponent: ${componentId} (type=${componentType}) to "${solutionUniqueName}"`,
 	);
 
 	try {
@@ -1826,7 +1785,7 @@ export async function isSolutionManaged(solutionUniqueName: string): Promise<boo
  * @returns Solution ID or null if not found
  */
 export async function getSolutionIdByUniqueName(
-	solutionUniqueName: string
+	solutionUniqueName: string,
 ): Promise<string | null> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -1875,7 +1834,7 @@ export async function exportToExcel(
 	viewType: "system" | "personal",
 	fetchXml: string,
 	layoutXml: string,
-	viewName: string
+	viewName: string,
 ): Promise<{ excelFile: string; filename: string }> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -1887,17 +1846,17 @@ export async function exportToExcel(
 			? {
 					"@odata.type": "Microsoft.Dynamics.CRM.savedquery",
 					savedqueryid: viewId,
-			  }
+				}
 			: {
 					"@odata.type": "Microsoft.Dynamics.CRM.userquery",
 					userqueryid: viewId,
-			  };
+				};
 
 	debugLog("exportAPI", `📡 ExportToExcel: ${viewType} view ${viewId}`);
 	debugLog("exportAPI", `📡 View object:`, viewObject);
 	debugLog(
 		"exportAPI",
-		`📡 FetchXML length: ${fetchXml.length}, LayoutXML length: ${layoutXml.length}`
+		`📡 FetchXML length: ${fetchXml.length}, LayoutXML length: ${layoutXml.length}`,
 	);
 
 	try {
@@ -1927,7 +1886,7 @@ export async function exportToExcel(
 
 		debugLog(
 			"exportAPI",
-			`✅ ExportToExcel successful, file size: ${result.ExcelFile?.length || 0} bytes`
+			`✅ ExportToExcel successful, file size: ${result.ExcelFile?.length || 0} bytes`,
 		);
 
 		return {
@@ -1946,33 +1905,37 @@ export async function exportToExcel(
  * @param filename - The filename for the download
  * @param mimeType - The MIME type of the file
  */
-export function downloadBase64File(
+export async function downloadBase64File(
 	base64Data: string,
 	filename: string,
-	mimeType: string = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-): void {
+	mimeType: string = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+): Promise<void> {
 	try {
-		// Convert Base64 to Blob
+		// Decode Base64 to binary buffer
 		const byteCharacters = atob(base64Data);
-		const byteNumbers = new Array(byteCharacters.length);
+		const byteArray = new Uint8Array(byteCharacters.length);
 		for (let i = 0; i < byteCharacters.length; i++) {
-			byteNumbers[i] = byteCharacters.charCodeAt(i);
+			byteArray[i] = byteCharacters.charCodeAt(i);
 		}
-		const byteArray = new Uint8Array(byteNumbers);
-		const blob = new Blob([byteArray], { type: mimeType });
 
-		// Create download link
+		// Use PPTB fileSystem.saveFile when running in the desktop host (opens native save dialog)
+		if (window.toolboxAPI?.fileSystem?.saveFile) {
+			const saved = await window.toolboxAPI.fileSystem.saveFile(filename, byteArray);
+			if (saved) {
+				debugLog("exportAPI", `✅ File saved via fileSystem: ${saved}`);
+			}
+			return;
+		}
+
+		// Fallback: browser blob download (standalone / dev context)
+		const blob = new Blob([byteArray], { type: mimeType });
 		const url = URL.createObjectURL(blob);
 		const link = document.createElement("a");
 		link.href = url;
 		link.download = filename;
-
-		// Trigger download
 		document.body.appendChild(link);
 		link.click();
 		document.body.removeChild(link);
-
-		// Clean up
 		URL.revokeObjectURL(url);
 
 		debugLog("exportAPI", `✅ File downloaded: ${filename}`);
@@ -2011,7 +1974,7 @@ export async function getEnvironmentUrl(): Promise<string | null> {
 export function buildRecordUrl(
 	entityName: string,
 	recordId: string,
-	environmentUrl: string
+	environmentUrl: string,
 ): string {
 	// Remove trailing slash from environmentUrl if present to avoid double slashes
 	const baseUrl = environmentUrl.endsWith("/") ? environmentUrl.slice(0, -1) : environmentUrl;
@@ -2103,14 +2066,14 @@ async function getBulkDeleteOperationId(asyncOperationId: string): Promise<strin
 		if (operations && operations.length > 0 && operations[0].bulkdeleteoperationid) {
 			debugLog(
 				"recordAPI",
-				`✅ Found bulkdeleteoperationid: ${operations[0].bulkdeleteoperationid}`
+				`✅ Found bulkdeleteoperationid: ${operations[0].bulkdeleteoperationid}`,
 			);
 			return operations[0].bulkdeleteoperationid;
 		}
 
 		debugLog(
 			"recordAPI",
-			`⚠️ No bulkdeleteoperationid found for asyncoperationid: ${asyncOperationId}`
+			`⚠️ No bulkdeleteoperationid found for asyncoperationid: ${asyncOperationId}`,
 		);
 		return "";
 	} catch (error) {
@@ -2133,7 +2096,7 @@ export async function submitBulkDelete(
 	entityLogicalName: string,
 	primaryIdAttribute: string,
 	recordIds: string[],
-	jobName: string
+	jobName: string,
 ): Promise<{ asyncOperationId: string; bulkDeleteOperationId: string; jobUrl: string }> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -2141,7 +2104,7 @@ export async function submitBulkDelete(
 
 	debugLog(
 		"recordAPI",
-		`📡 Submitting bulk delete job: ${jobName} for ${recordIds.length} records`
+		`📡 Submitting bulk delete job: ${jobName} for ${recordIds.length} records`,
 	);
 
 	try {
@@ -2192,7 +2155,7 @@ export async function submitBulkDelete(
 
 		debugLog(
 			"recordAPI",
-			`✅ Bulk delete job submitted: asyncOpId=${asyncOpId}, bulkDeleteOpId=${bulkDeleteOpId}`
+			`✅ Bulk delete job submitted: asyncOpId=${asyncOpId}, bulkDeleteOpId=${bulkDeleteOpId}`,
 		);
 
 		return {
@@ -2290,7 +2253,7 @@ export async function getOnDemandWorkflows(entityLogicalName: string): Promise<W
 export async function executeWorkflow(
 	workflowId: string,
 	recordId: string,
-	entityLogicalName: string
+	entityLogicalName: string,
 ): Promise<void> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -2298,7 +2261,7 @@ export async function executeWorkflow(
 
 	debugLog(
 		"workflowAPI",
-		`📡 Executing workflow ${workflowId} on ${entityLogicalName}(${recordId})`
+		`📡 Executing workflow ${workflowId} on ${entityLogicalName}(${recordId})`,
 	);
 
 	try {
@@ -2347,7 +2310,7 @@ export async function executeWorkflowBatch(
 	recordIds: string[],
 	entityLogicalName: string,
 	onProgress?: (progress: WorkflowBatchProgress) => void,
-	batchSize: number = 10
+	batchSize: number = 10,
 ): Promise<{ succeeded: number; failed: number; errors: string[] }> {
 	const result = { succeeded: 0, failed: 0, errors: [] as string[] };
 	const total = recordIds.length;
@@ -2361,7 +2324,7 @@ export async function executeWorkflowBatch(
 
 	debugLog(
 		"workflowAPI",
-		`📡 Executing workflow ${workflowId} on ${recordIds.length} records in ${batches.length} batches`
+		`📡 Executing workflow ${workflowId} on ${recordIds.length} records in ${batches.length} batches`,
 	);
 
 	// Track timing for ETA calculation
@@ -2375,7 +2338,7 @@ export async function executeWorkflowBatch(
 
 		debugLog(
 			"workflowAPI",
-			`📡 Executing batch ${batchIndex + 1}/${batches.length} with ${batchRecordIds.length} records`
+			`📡 Executing batch ${batchIndex + 1}/${batches.length} with ${batchRecordIds.length} records`,
 		);
 
 		// Execute workflows in parallel within the batch
@@ -2430,7 +2393,7 @@ export async function executeWorkflowBatch(
 
 	debugLog(
 		"workflowAPI",
-		`✅ Workflow execution complete: ${result.succeeded} succeeded, ${result.failed} failed`
+		`✅ Workflow execution complete: ${result.succeeded} succeeded, ${result.failed} failed`,
 	);
 	return result;
 }
@@ -2488,7 +2451,7 @@ export async function deleteRecordsBatch(
 	entitySetName: string,
 	recordIds: string[],
 	onProgress?: (progress: BatchDeleteProgress) => void,
-	batchSize: number = 10
+	batchSize: number = 10,
 ): Promise<BatchDeleteResult> {
 	const result: BatchDeleteResult = { succeeded: 0, failed: 0, errors: [] };
 	const total = recordIds.length;
@@ -2563,7 +2526,7 @@ export async function deleteRecordsBatch(
 
 	debugLog(
 		"recordAPI",
-		`✅ Delete complete: ${result.succeeded} succeeded, ${result.failed} failed`
+		`✅ Delete complete: ${result.succeeded} succeeded, ${result.failed} failed`,
 	);
 	return result;
 }
@@ -2578,7 +2541,7 @@ export async function deleteRecordsBatch(
  */
 export async function submitBulkDeleteFromFetchXml(
 	fetchXml: string,
-	jobName: string
+	jobName: string,
 ): Promise<{ asyncOperationId: string; bulkDeleteOperationId: string; jobUrl: string }> {
 	if (!isDataverseAvailable()) {
 		throw new Error("PPTB Dataverse API not available");
@@ -2620,7 +2583,7 @@ export async function submitBulkDeleteFromFetchXml(
 
 		debugLog(
 			"recordAPI",
-			`✅ Bulk delete job submitted: asyncOpId=${asyncOpId}, bulkDeleteOpId=${bulkDeleteOpId}`
+			`✅ Bulk delete job submitted: asyncOpId=${asyncOpId}, bulkDeleteOpId=${bulkDeleteOpId}`,
 		);
 
 		return {

--- a/src/shared/hooks/usePptbContext.ts
+++ b/src/shared/hooks/usePptbContext.ts
@@ -9,40 +9,17 @@ export interface PptbContext {
 	theme: "light" | "dark";
 	connected: boolean;
 	environmentUrl?: string;
-	organizationId?: string;
+	environment?: "Dev" | "Test" | "UAT" | "Production";
 }
 
-// PPTB Event payload structure
-interface ToolBoxEventPayload {
+// PPTB event payload type (compatible with @pptb/types ToolBoxEventPayload)
+type ToolBoxEventPayload = {
 	event: string;
 	data: unknown;
 	timestamp?: string;
-}
+};
 
-// Extend window interface for PPTB API
-declare global {
-	interface Window {
-		toolboxAPI?: {
-			utils?: {
-				getCurrentTheme?: () => Promise<"light" | "dark">;
-			};
-			connections?: {
-				getActiveConnection?: () => Promise<{
-					url?: string;
-					organizationId?: string;
-					name?: string;
-					environment?: string;
-				} | null>;
-			};
-			events?: {
-				// PPTB uses a single callback that receives all events
-				on?: (callback: (event: unknown, payload: ToolBoxEventPayload) => void) => void;
-				off?: (callback: (event: unknown, payload: ToolBoxEventPayload) => void) => void;
-				getHistory?: (count: number) => Promise<ToolBoxEventPayload[]>;
-			};
-		};
-	}
-}
+// NOTE: window.toolboxAPI global types are provided by @pptb/types (see tsconfig.app.json)
 
 /**
  * Get tool context from PPTB host
@@ -91,7 +68,7 @@ export function usePptbContext(): PptbContext {
 					...prev,
 					connected: !!connection,
 					environmentUrl: connection?.url,
-					organizationId: connection?.organizationId,
+					environment: connection?.environment,
 				}));
 			} catch (err) {
 				console.warn("❌ Failed to get active connection:", err);
@@ -134,7 +111,7 @@ export function usePptbContext(): PptbContext {
 						...prev,
 						connected: false,
 						environmentUrl: undefined,
-						organizationId: undefined,
+						environment: undefined,
 					}));
 					break;
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "@pptb/types"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
- Upgrade @pptb/types devDependency: ^1.0.7 → ^1.2.0
- Add @pptb/types to tsconfig.app.json types array for global Window augmentation
- Remove hand-written window.dataverseAPI declaration from pptbClient.ts
- Remove hand-written window.toolboxAPI declaration from usePptbContext.ts
- Add local DataverseFetchXmlResponse for OData annotations beyond @pptb/types FetchXmlResult
- Migrate downloadBase64File() and downloadExcelFile() to async with fileSystem.saveFile (native OS save dialog in PPTB host; browser blob fallback in standalone/dev)
- Update PptbContext: replace organizationId with environment (Dev/Test/UAT/Production)
- Update package.json: icon field, features block (multiConnection=none, minAPI=1.2.0), cspExceptions object format, validate + finalize-package scripts, remove deprecated iconUrl
- Bump version 1.0.6 → 1.1.0
- Update README.md: fix React version, version badges, tech stack table, export/privilege/ UX feature sections, project structure, building commands
- Update CHANGELOG.md: add [1.1.0] entry

TypeScript: zero errors (tsc -b --noEmit)
pptb-validate: Validation passed

## Summary

What does this PR change and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build/CI

## How to test

Steps to validate the change.

## Screenshots (if UI)

Before/After images or recordings.

## Checklist

- [ ] Added/updated tests (if applicable)
- [x] Updated docs (if applicable)
- [x] No secrets included (tokens/keys)
- [ ] Accessibility considered (keyboard/nav/contrast)
