### PR TITLE
fix: alias validation, editor tab persistence, grid alignment (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to FetchXML Studio will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-04-07
+
+### ✨ Added
+
+- **Copy button in editor mode** — The FetchXML editor toolbar now includes a Copy button when in editor mode, making it consistent with the read-only toolbar. Previously Copy was only available when the editor was not in edit mode.
+
+### 🔧 Fixed
+
+- **Results grid column overlap** — Column widths are now estimated dynamically from header text (capped at 400 px) so adjacent columns no longer overlap on first render. All cells use `TableCellLayout truncate` for clean overflow.
+- **Results grid header/row misalignment** — Removed a stray CSS class from `DataGridBody` that was causing header and row widths to drift out of sync when the grid had overflowing content.
+- **Alias validation in property editors** — Typing an invalid alias character (space, hyphen, special character) in `AttributeEditor` or `LinkEntityEditor` now sanitizes the value in real time: invalid characters are stripped, and a leading digit is prefixed with `_`.
+- **Alias validation in parser** — When parsing FetchXML (both *Parse to Tree* and *Execute*), invalid aliases are now automatically sanitized. A parse warning describes the correction (e.g. *"Alias 'this is id' had invalid characters and was corrected to 'thisisid'."*) instead of silently forwarding the invalid alias to Dataverse where it would cause an API error.
+- **Execute blocked when alias warnings are present** — Clicking Execute in editor mode now validates the XML completely before sending it to Dataverse. If parse warnings exist (e.g. an invalid alias that wasn't auto-corrected via *Parse to Tree*), execution is blocked and the warning is surfaced in a message bar above the editor with a hint to use *Parse to Tree* to auto-correct. Previously the bad alias was silently sent to Dataverse and the error appeared in the Results tab.
+- **Editor state preserved across tab switches** — Switching from the FetchXML tab to Results or LayoutXML and back no longer resets editor mode or discards the edited XML. The editor component is now always mounted (hidden via `display: none` when not active) so Monaco state — editor mode toggle, cursor position, edit buffer — is fully preserved.
+- **Validate contradictory messages** — *Validate* no longer shows both a "Valid" success message and warnings simultaneously. When warnings are present, validate now shows each warning plus an "Action required" notice and stops — the "Valid" success message is only shown when there are zero warnings.
+- **Parse to Tree corrections shown as informational** — Auto-corrected alias warnings from *Parse to Tree* are now shown with `intent="info"` (blue) rather than `intent="warning"` (yellow), correctly communicating that the tool has already resolved the problem.
+- **Execute API errors surfaced** — Dataverse API errors that occur during query execution are now captured and displayed in a message bar in the Results tab. Previously they were only visible in the browser console.
+
+### 🏗️ Technical
+
+- Added `src/features/fetchxml/model/aliasUtils.ts` — `isValidAlias()` and `sanitizeAlias()` shared utilities enforcing the Dataverse alias constraint (`[A-Za-z_][A-Za-z0-9_]*`).
+- `fetchxmlParser.ts` — `parseAttribute` and `parseLinkEntity` now import `sanitizeAlias`; invalid aliases are corrected in place and described in the parse warning rather than propagated as-is.
+- `PreviewTabs.tsx` — `FetchXmlEditor` is always mounted; `handleExecute` blocks on parse warnings; navigating back to the FetchXML tab clears any stale editor validation error banner.
+- `AppShell.tsx` — `handleExecute` accepts an optional `xmlOverride` (used when editor mode is active); `executeError` state threads Dataverse API errors back to the `PreviewTabs` message bar.
+
+---
+
 ## [1.2.0] - 2026-04-03
 
 ### ✨ Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A powerful, modern FetchXML query builder and data explorer for [Power Platform ToolBox](https://github.com/PowerPlatformToolBox/desktop-app). Inspired by the XrmToolBox FetchXML Builder, reimagined with React 18, Fluent UI v9, and seamless Dataverse integration.
 
-![Version](https://img.shields.io/badge/version-1.2.0-blue)
+![Version](https://img.shields.io/badge/version-1.2.1-blue)
 ![React](https://img.shields.io/badge/React-18-61DAFB?logo=react)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript)
 ![Fluent UI](https://img.shields.io/badge/Fluent%20UI-v9-0078D4?logo=microsoft)
@@ -26,9 +26,10 @@ A powerful, modern FetchXML query builder and data explorer for [Power Platform 
 - **Formatted values** — Display OData formatted values or raw values (configurable)
 
 ### 📝 FetchXML Editor
-- **Monaco editor** — Full-featured XML editor with syntax highlighting and line numbers
+- **Monaco editor** — Full-featured XML editor with XML syntax highlighting and line numbers
 - **Bi-directional editing** — Edit XML directly and parse back to the visual builder
-- **Copy to clipboard** — One-click copy of generated FetchXML
+- **Copy to clipboard** — One-click copy of generated FetchXML, available in both read-only and editor modes
+- **Alias validation** — Invalid alias characters are sanitized in real time in the property editors; the parser auto-corrects aliases on Parse to Tree with a clear description of each correction
 - **LayoutXML preview** — See the column layout configuration
 
 ### 📥 Load & Save Views

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mohsinonxrm/pptb-fetchxml-studio",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"type": "module",
 	"displayName": "FetchXML Studio",
 	"description": "A powerful, modern FetchXML query builder and data explorer for Microsoft Dataverse and Dynamics 365.",

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -2,7 +2,7 @@
  * Main application shell with Fluent UI theming and layout
  */
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import {
 	FluentProvider,
 	webLightTheme,
@@ -274,6 +274,14 @@ function AppContent() {
 		hasPrivilege: false,
 		privilegeChecked: false,
 	});
+
+	// Execution error (e.g. Dataverse API error surfaced to user)
+	const [executeError, setExecuteError] = useState<string | undefined>();
+
+	// The XML that was actually sent to Dataverse for the most recent execution.
+	// Used by loadAllPages / handleLoadMore so subsequent pages use the same XML
+	// (which may differ from the tree-generated fetchXml when editor mode was active).
+	const lastExecutedXmlRef = useRef<string>("");
 
 	// Record action privileges state
 	const [recordActionPrivileges, setRecordActionPrivileges] = useState<{
@@ -712,13 +720,19 @@ function AppContent() {
 
 	/**
 	 * Execute the query and handle Retrieve All if enabled
+	 * @param xmlOverride - when provided (editor mode), use this XML instead of the tree-generated one
 	 */
-	const handleExecute = async () => {
-		if (!fetchXml) return;
+	const handleExecute = async (xmlOverride?: string) => {
+		const xmlToExecute = xmlOverride ?? fetchXml;
+		if (!xmlToExecute) return;
 
 		setIsExecuting(true);
 		setQueryResult(null);
 		setPagingState(null);
+		setExecuteError(undefined);
+
+		// Remember what XML was sent so loadAllPages / handleLoadMore use the same query
+		lastExecutedXmlRef.current = xmlToExecute;
 
 		const startTime = performance.now();
 		const entityLogicalName = builder.fetchQuery?.entity.name;
@@ -730,14 +744,15 @@ function AppContent() {
 		const pageSize = builder.fetchQuery?.options?.count;
 
 		try {
-			// Determine execution method based on loaded view state
+			// Determine execution method based on loaded view state.
+			// Only use view-based execution when using tree XML (not editor override).
 			let result;
 			const loadedView = builder.loadedView;
 			let useViewExecution = false;
 
-			if (loadedView) {
+			if (!xmlOverride && loadedView) {
 				const isUnmodified =
-					fetchXml.replace(/\s+/g, "") === loadedView.originalFetchXml.replace(/\s+/g, "");
+					xmlToExecute.replace(/\s+/g, "") === loadedView.originalFetchXml.replace(/\s+/g, "");
 
 				if (isUnmodified) {
 					useViewExecution = true;
@@ -755,14 +770,16 @@ function AppContent() {
 				}
 			}
 
-			// If not using view execution (either no view or view was modified), use FetchXML
+			// If not using view execution (either no view, view was modified, or editor override), use FetchXML
 			if (!result) {
 				console.log(
-					loadedView
-						? `📝 View "${loadedView.name}" was modified - executing via fetchXmlQuery`
-						: "📡 Executing FetchXML query",
+					xmlOverride
+						? "✏️ Executing editor FetchXML"
+						: loadedView
+							? `📝 View "${loadedView.name}" was modified - executing via fetchXmlQuery`
+							: "📡 Executing FetchXML query",
 				);
-				result = await executeFetchXml(fetchXml);
+				result = await executeFetchXml(xmlToExecute);
 			}
 
 			const executionTimeMs = Math.round(performance.now() - startTime);
@@ -795,7 +812,7 @@ function AppContent() {
 			// Don't do Retrieve All if user set a 'top' limit - Dataverse handles the limit
 			if (retrieveAll && result.moreRecords && !useViewExecution && !hasTopLimit) {
 				await loadAllPages(
-					fetchXml,
+					xmlToExecute,
 					columns,
 					rows,
 					result.pagingCookie,
@@ -806,6 +823,11 @@ function AppContent() {
 			}
 		} catch (error) {
 			console.error("Failed to execute FetchXML:", error);
+			const message =
+				error instanceof Error
+					? error.message
+					: "An unexpected error occurred while executing the query.";
+			setExecuteError(message);
 			setQueryResult({ columns: [], rows: [] });
 			setIsExecuting(false);
 		}
@@ -885,7 +907,8 @@ function AppContent() {
 	 * Load more records (for infinite scroll when Retrieve All is OFF)
 	 */
 	const handleLoadMore = async () => {
-		if (!fetchXml || !pagingState || !pagingState.moreRecords || isLoadingMore) return;
+		const xmlToPage = lastExecutedXmlRef.current || fetchXml;
+		if (!xmlToPage || !pagingState || !pagingState.moreRecords || isLoadingMore) return;
 		if (pagingState.isRetrieveAllInProgress) return; // Don't allow manual load during Retrieve All
 
 		// Don't load more if user has set a 'top' limit
@@ -904,7 +927,7 @@ function AppContent() {
 
 			// Add paging parameters: page number, paging cookie (required for reliable paging), and count (page size)
 			const pagedFetchXml = addPagingToFetchXml(
-				fetchXml,
+				xmlToPage,
 				nextPage,
 				pagingState.pagingCookie,
 				pageSize,
@@ -1494,6 +1517,8 @@ function AppContent() {
 					isExporting={exportStatus.isExporting}
 					exportError={exportStatus.error}
 					onDismissExportError={() => setExportStatus((prev) => ({ ...prev, error: undefined }))}
+					executeError={executeError}
+					onDismissExecuteError={() => setExecuteError(undefined)}
 					exportDisabledReason={
 						!builder.loadedView
 							? "Save as a view first to enable export"

--- a/src/features/fetchxml/model/aliasUtils.ts
+++ b/src/features/fetchxml/model/aliasUtils.ts
@@ -1,0 +1,36 @@
+/**
+ * Utilities for validating and sanitizing FetchXML alias values.
+ *
+ * Dataverse alias rules:
+ *   - Allowed characters: [A-Za-z0-9_]
+ *   - First character must be a letter or underscore: [A-Za-z_]
+ */
+
+const ALIAS_INVALID_CHARS = /[^A-Za-z0-9_]/g;
+const ALIAS_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Returns true when the alias is either empty (no alias) or matches the
+ * Dataverse alias character rules.
+ */
+export function isValidAlias(alias: string): boolean {
+	if (!alias) return true;
+	return ALIAS_REGEX.test(alias);
+}
+
+/**
+ * Strips characters not allowed in a Dataverse alias and fixes a leading
+ * digit by prepending an underscore.  Returns an empty string when the
+ * input was empty or consisted entirely of invalid characters.
+ */
+export function sanitizeAlias(raw: string): string {
+	// Remove every character that is not [A-Za-z0-9_]
+	let sanitized = raw.replace(ALIAS_INVALID_CHARS, "");
+
+	// First character must not be a digit
+	if (sanitized.length > 0 && /^\d/.test(sanitized)) {
+		sanitized = `_${sanitized}`;
+	}
+
+	return sanitized;
+}

--- a/src/features/fetchxml/model/fetchxmlParser.ts
+++ b/src/features/fetchxml/model/fetchxmlParser.ts
@@ -16,6 +16,7 @@ import type {
 	OperatorType,
 	NodeId,
 } from "./nodes";
+import { isValidAlias, sanitizeAlias } from "./aliasUtils";
 
 // ID generator for parsed nodes
 let parseIdCounter = 0;
@@ -366,7 +367,21 @@ function parseAttribute(attrElement: Element, warnings: ParseWarning[]): Attribu
 
 	// Optional attributes
 	const alias = attrElement.getAttribute("alias");
-	if (alias) attr.alias = alias;
+	if (alias) {
+		if (!isValidAlias(alias)) {
+			const sanitized = sanitizeAlias(alias);
+			warnings.push({
+				message: sanitized
+					? `Alias '${alias}' had invalid characters and was corrected to '${sanitized}'.`
+					: `Alias '${alias}' had no valid characters and was removed.`,
+				element: "attribute",
+				attribute: "alias",
+			});
+			if (sanitized) attr.alias = sanitized;
+		} else {
+			attr.alias = alias;
+		}
+	}
 
 	if (attrElement.getAttribute("groupby") === "true") {
 		attr.groupby = true;
@@ -629,7 +644,21 @@ function parseLinkEntity(linkElement: Element, warnings: ParseWarning[]): LinkEn
 
 	// Optional attributes
 	const alias = linkElement.getAttribute("alias");
-	if (alias) link.alias = alias;
+	if (alias) {
+		if (!isValidAlias(alias)) {
+			const sanitized = sanitizeAlias(alias);
+			warnings.push({
+				message: sanitized
+					? `Alias '${alias}' had invalid characters and was corrected to '${sanitized}'.`
+					: `Alias '${alias}' had no valid characters and was removed.`,
+				element: "link-entity",
+				attribute: "alias",
+			});
+			if (sanitized) link.alias = sanitized;
+		} else {
+			link.alias = alias;
+		}
+	}
 
 	if (linkElement.getAttribute("intersect") === "true") {
 		link.intersect = true;

--- a/src/features/fetchxml/ui/LeftPane/PropertiesPanel/editors/AttributeEditor.tsx
+++ b/src/features/fetchxml/ui/LeftPane/PropertiesPanel/editors/AttributeEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from "@fluentui/react-components";
 import { Info16Regular } from "@fluentui/react-icons";
 import type { AttributeNode } from "../../../../model/nodes";
+import { sanitizeAlias } from "../../../../model/aliasUtils";
 import { AttributePicker } from "../../../../../../shared/components/AttributePicker";
 
 const useStyles = makeStyles({
@@ -58,9 +59,9 @@ export function AttributeEditor({
 
 	const handleTextChange = (field: string) => (_: unknown, data: { value: string }) => {
 		let value = data.value;
-		// For alias field, remove spaces (aliases cannot contain spaces)
+		// Aliases must use only [A-Za-z0-9_] with a letter or underscore as first char
 		if (field === "alias") {
-			value = value.replace(/\s/g, "");
+			value = sanitizeAlias(value);
 		}
 		onUpdate({ [field]: value || undefined });
 	};
@@ -105,7 +106,7 @@ export function AttributeEditor({
 							placeholder="e.g., account_name, total_value"
 						/>
 						<Tooltip
-							content="Optional alias for the column in results. Useful for aggregate queries or when joining multiple entities."
+							content="Optional alias for the column in results. May only contain letters, digits, and underscores, and must start with a letter or underscore."
 							relationship="description"
 						>
 							<Info16Regular className={styles.tooltipIcon} />

--- a/src/features/fetchxml/ui/LeftPane/PropertiesPanel/editors/LinkEntityEditor.tsx
+++ b/src/features/fetchxml/ui/LeftPane/PropertiesPanel/editors/LinkEntityEditor.tsx
@@ -27,6 +27,7 @@ import {
 import { Info16Regular } from "@fluentui/react-icons";
 import { debugLog } from "../../../../../../shared/utils/debug";
 import type { LinkEntityNode, LinkType } from "../../../../model/nodes";
+import { sanitizeAlias } from "../../../../model/aliasUtils";
 import { RelationshipPicker } from "../../../../../../shared/components/RelationshipPicker";
 
 const useStyles = makeStyles({
@@ -116,7 +117,12 @@ export function LinkEntityEditor({ node, parentEntityName, onUpdate }: LinkEntit
 	}, [node.id, node.name, node.from, node.to, parentEntityName, shouldShowPicker]);
 
 	const handleTextChange = (field: string) => (_: unknown, data: { value: string }) => {
-		onUpdate({ [field]: data.value || undefined });
+		let value = data.value;
+		// Aliases must use only [A-Za-z0-9_] with a letter or underscore as first char
+		if (field === "alias") {
+			value = sanitizeAlias(value);
+		}
+		onUpdate({ [field]: value || undefined });
 	};
 
 	// Special handler for link-type changes that may require confirmation
@@ -360,7 +366,7 @@ export function LinkEntityEditor({ node, parentEntityName, onUpdate }: LinkEntit
 							placeholder="e.g., parent_account, created_by_user"
 						/>
 						<Tooltip
-							content="Alias for referencing this link in conditions, order-by, or nested links."
+							content="Alias for referencing this link in conditions, order-by, or nested links. May only contain letters, digits, and underscores, and must start with a letter or underscore."
 							relationship="description"
 						>
 							<Info16Regular className={styles.tooltipIcon} />

--- a/src/features/fetchxml/ui/RightPane/DataGridCellRenderers.tsx
+++ b/src/features/fetchxml/ui/RightPane/DataGridCellRenderers.tsx
@@ -17,25 +17,48 @@ const useStyles = makeStyles({
 		display: "flex",
 		flexDirection: "column",
 		gap: "2px",
+		minWidth: 0, // required for flex child to clip overflow
 	},
 	lookupName: {
+		display: "block",
 		fontSize: tokens.fontSizeBase200,
 		fontWeight: tokens.fontWeightSemibold,
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
 	},
 	lookupType: {
+		display: "block",
 		fontSize: tokens.fontSizeBase100,
 		color: tokens.colorNeutralForeground3,
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
 	},
 	numberCell: {
+		display: "block",
 		textAlign: "right",
 		fontVariantNumeric: "tabular-nums",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
 	},
 	dateCell: {
+		display: "block",
 		fontVariantNumeric: "tabular-nums",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
 	},
 	picklistCell: {
 		display: "flex",
 		alignItems: "center",
+	},
+	truncateText: {
+		display: "block",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
 	},
 });
 
@@ -287,6 +310,7 @@ export function TextCellRenderer({
 	value: unknown;
 	formattedValue?: unknown;
 }) {
+	const styles = useStyles();
 	// Prefer formatted value
 	const displayValue = formattedValue ?? value;
 
@@ -294,7 +318,7 @@ export function TextCellRenderer({
 		return <span>—</span>;
 	}
 
-	return <span>{String(displayValue)}</span>;
+	return <span className={styles.truncateText}>{String(displayValue)}</span>;
 }
 
 /**
@@ -312,7 +336,7 @@ export function getCellRenderer(
 	attributeType: string | undefined,
 	value: unknown,
 	formattedValue: unknown | undefined,
-	attribute?: AttributeMetadata
+	attribute?: AttributeMetadata,
 ) {
 	if (value === null || value === undefined) {
 		return <span>—</span>;

--- a/src/features/fetchxml/ui/RightPane/FetchXmlEditor.tsx
+++ b/src/features/fetchxml/ui/RightPane/FetchXmlEditor.tsx
@@ -101,9 +101,15 @@ interface Message {
 interface FetchXmlEditorProps {
 	xml: string;
 	onParseToTree?: (xmlString: string) => ParseResult;
+	/**
+	 * Called whenever editor mode or its content changes.
+	 * `isActive=false` means editor mode is off (parent should use tree XML).
+	 * `isActive=true` means editor mode is on; `xml` is the current editor content.
+	 */
+	onEditorStateChange?: (isActive: boolean, xml: string) => void;
 }
 
-export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
+export function FetchXmlEditor({ xml, onParseToTree, onEditorStateChange }: FetchXmlEditorProps) {
 	const styles = useStyles();
 	const { isDark } = useTheme();
 	const editorRef = useRef<MonacoEditor.editor.IStandaloneCodeEditor | null>(null);
@@ -146,10 +152,13 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 				// Entering editor mode - copy current XML to edit buffer
 				setEditedXml(xml);
 				clearMessages();
+				onEditorStateChange?.(true, xml);
+			} else {
+				onEditorStateChange?.(false, "");
 			}
 			setIsEditorMode(checked);
 		},
-		[xml, clearMessages]
+		[xml, clearMessages, onEditorStateChange],
 	);
 
 	// Copy to clipboard
@@ -169,13 +178,14 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 			const text = await navigator.clipboard.readText();
 			if (text.trim()) {
 				setEditedXml(text);
+				onEditorStateChange?.(true, text);
 				addMessage("info", "Pasted", "Content pasted from clipboard");
 			}
 		} catch (err) {
 			console.error("Failed to paste:", err);
 			addMessage("error", "Paste failed", "Could not read from clipboard");
 		}
-	}, [addMessage]);
+	}, [addMessage, onEditorStateChange]);
 
 	// Load from file
 	const handleLoadFile = useCallback(() => {
@@ -190,6 +200,7 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 				reader.onload = (e) => {
 					const content = e.target?.result as string;
 					setEditedXml(content);
+					onEditorStateChange?.(true, content);
 					addMessage("info", "File loaded", `Loaded ${file.name}`);
 				};
 				reader.onerror = () => {
@@ -200,15 +211,16 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 			// Reset input so same file can be loaded again
 			event.target.value = "";
 		},
-		[addMessage]
+		[addMessage],
 	);
 
 	// Reset to tree-generated XML
 	const handleReset = useCallback(() => {
 		setEditedXml(xml);
+		onEditorStateChange?.(true, xml);
 		clearMessages();
 		addMessage("info", "Reset", "Reverted to tree-generated FetchXML");
-	}, [xml, clearMessages, addMessage]);
+	}, [xml, clearMessages, addMessage, onEditorStateChange]);
 
 	// Validate XML
 	const handleValidate = useCallback(() => {
@@ -230,15 +242,21 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 			return;
 		}
 
-		// Show warnings if any
+		// Warnings indicate problems that must be fixed before executing
 		if (parseResult.warnings.length > 0) {
 			parseResult.warnings.forEach((warn: ParseWarning) => {
 				const prefix = warn.element ? `<${warn.element}>: ` : "";
 				addMessage("warning", "Warning", `${prefix}${warn.message}`);
 			});
+			addMessage(
+				"warning",
+				"Action required",
+				"Fix the warnings above before executing, or use 'Parse to Tree' to auto-correct.",
+			);
+			return; // Do not show 'Valid' alongside warnings
 		}
 
-		addMessage("success", "Valid", "FetchXML is valid and ready to parse");
+		addMessage("success", "Valid", "FetchXML is valid and free of issues.");
 	}, [editedXml, clearMessages, addMessage]);
 
 	// Parse to tree
@@ -249,20 +267,21 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 		const result = onParseToTree(editedXml);
 
 		if (result.success) {
-			// Show warnings but still success
+			// Show auto-corrections as informational (not blocking warnings)
 			result.warnings.forEach((warn: ParseWarning) => {
 				const prefix = warn.element ? `<${warn.element}>: ` : "";
-				addMessage("warning", "Warning", `${prefix}${warn.message}`);
+				addMessage("info", "Auto-corrected", `${prefix}${warn.message}`);
 			});
 			addMessage("success", "Parsed", "FetchXML loaded into tree builder");
 			// Exit editor mode after successful parse
+			onEditorStateChange?.(false, "");
 			setIsEditorMode(false);
 		} else {
 			result.errors.forEach((err: ParseError) => {
 				addMessage("error", "Parse Error", err.message);
 			});
 		}
-	}, [editedXml, onParseToTree, clearMessages, addMessage]);
+	}, [editedXml, onParseToTree, clearMessages, addMessage, onEditorStateChange]);
 
 	// Handle editor mount
 	const handleEditorMount = useCallback(
@@ -272,7 +291,7 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 			registerFetchXmlIntellisense(monaco);
 			registerFetchXmlHoverProvider(monaco);
 		},
-		[]
+		[],
 	);
 
 	return (
@@ -282,6 +301,11 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 				<div className={styles.toolbarLeft}>
 					{isEditorMode ? (
 						<Toolbar size="small">
+							<Tooltip content="Copy FetchXML to clipboard" relationship="label">
+								<ToolbarButton icon={<Copy24Regular />} onClick={handleCopy}>
+									Copy
+								</ToolbarButton>
+							</Tooltip>
 							<Tooltip content="Paste from clipboard" relationship="label">
 								<ToolbarButton icon={<ClipboardPaste24Regular />} onClick={handlePaste}>
 									Paste
@@ -347,7 +371,14 @@ export function FetchXmlEditor({ xml, onParseToTree }: FetchXmlEditorProps) {
 					language="xml"
 					theme={isDark ? "vs-dark" : "vs"}
 					value={currentXml}
-					onChange={isEditorMode ? (value) => setEditedXml(value || "") : undefined}
+					onChange={
+						isEditorMode
+							? (value) => {
+									setEditedXml(value || "");
+									onEditorStateChange?.(true, value || "");
+								}
+							: undefined
+					}
 					loading={
 						<div className={styles.loadingContainer}>
 							<Spinner size="medium" label="Loading editor..." />

--- a/src/features/fetchxml/ui/RightPane/PreviewTabs.tsx
+++ b/src/features/fetchxml/ui/RightPane/PreviewTabs.tsx
@@ -2,7 +2,7 @@
  * Tabbed preview panel with FetchXML editor and Results grid
  */
 
-import { useState, useCallback, type ReactNode } from "react";
+import { useState, useCallback, useRef, type ReactNode } from "react";
 import {
 	TabList,
 	Tab,
@@ -28,6 +28,7 @@ import type { RelatedEntityColumn } from "./AddColumnsPanel";
 import type { AttributeMetadata, RelationshipMetadata } from "../../api/pptbClient";
 import type { FetchNode } from "../../model/nodes";
 import type { ParseResult } from "../../model/fetchxmlParser";
+import { validateFetchXmlSyntax, parseFetchXml } from "../../model/fetchxmlParser";
 import type { LayoutXmlConfig } from "../../model/layoutxml";
 import type { WorkflowInfo } from "../../api/pptbClient";
 import type { DisplaySettings } from "../../model/displaySettings";
@@ -123,7 +124,7 @@ interface PreviewTabsProps {
 	isExecuting?: boolean;
 	/** Whether more pages are being loaded (for progress display) */
 	isLoadingMore?: boolean;
-	onExecute?: () => void;
+	onExecute?: (xmlOverride?: string) => void;
 	/** Export via Dataverse ExportToExcel API */
 	onExport?: () => void;
 	/** Export locally using exceljs */
@@ -132,6 +133,10 @@ interface PreviewTabsProps {
 	/** Multi-entity attribute metadata: Map<entityLogicalName, Map<attributeLogicalName, AttributeMetadata>> */
 	attributeMetadata?: Map<string, Map<string, AttributeMetadata>>;
 	fetchQuery?: FetchNode | null;
+	/** Error message from a failed query execution (e.g. Dataverse API error) */
+	executeError?: string;
+	/** Callback to dismiss the execute error */
+	onDismissExecuteError?: () => void;
 	/** Column layout configuration for ordering and sizing */
 	columnConfig?: LayoutXmlConfig | null;
 	/** Callback when column width changes */
@@ -235,6 +240,8 @@ export function PreviewTabs({
 	exportError,
 	onDismissExportError,
 	exportDisabledReason,
+	executeError,
+	onDismissExecuteError,
 	entityDisplayName,
 	lookupRelationships,
 	oneToManyRelationships,
@@ -264,14 +271,68 @@ export function PreviewTabs({
 	const [toolbarSelectedCount, setToolbarSelectedCount] = useState(0);
 	const [selectedRecordIds, setSelectedRecordIds] = useState<string[]>([]);
 
+	// Track editor mode state via ref (avoids re-renders on each keystroke)
+	// isEditorModeActive in state controls the disabled prop + renders; the ref holds the latest XML.
+	const [isEditorModeActive, setIsEditorModeActive] = useState(false);
+	const editorXmlRef = useRef<string>("");
+	const [editorValidationError, setEditorValidationError] = useState<string | null>(null);
+
+	const handleEditorStateChange = useCallback((isActive: boolean, editorXml: string) => {
+		editorXmlRef.current = editorXml;
+		setIsEditorModeActive((prev) => (prev !== isActive ? isActive : prev));
+		if (!isActive) {
+			setEditorValidationError(null);
+		}
+	}, []);
+
 	const handleTabSelect = (_event: SelectTabEvent, data: SelectTabData) => {
 		setSelectedTab(data.value as "xml" | "layout" | "results");
+		// Clear the editor validation error when returning to the XML tab so it
+		// doesn't linger as a banner on top of the editor.
+		if (data.value === "xml") {
+			setEditorValidationError(null);
+		}
 	};
 
 	const handleExecute = () => {
-		// Switch to Results tab when executing
-		setSelectedTab("results");
-		onExecute?.();
+		setEditorValidationError(null);
+
+		if (isEditorModeActive) {
+			const editorXml = editorXmlRef.current;
+
+			// Client-side validation before sending to Dataverse
+			const syntaxResult = validateFetchXmlSyntax(editorXml);
+			if (!syntaxResult.valid) {
+				setEditorValidationError(syntaxResult.error || "Invalid XML syntax");
+				return;
+			}
+
+			const parseResult = parseFetchXml(editorXml);
+			if (!parseResult.success) {
+				setEditorValidationError(parseResult.errors.map((e) => e.message).join(" | "));
+				return;
+			}
+
+			// Warnings (e.g. invalid aliases) will be rejected by Dataverse — block execution
+			if (parseResult.warnings.length > 0) {
+				const warningText = parseResult.warnings
+					.map((w) => {
+						const prefix = w.element ? `<${w.element}>: ` : "";
+						return `${prefix}${w.message}`;
+					})
+					.join(" | ");
+				setEditorValidationError(
+					`Fix before executing — ${warningText} Use 'Parse to Tree' to auto-correct.`,
+				);
+				return;
+			}
+
+			setSelectedTab("results");
+			onExecute?.(editorXml);
+		} else {
+			setSelectedTab("results");
+			onExecute?.();
+		}
 	};
 
 	const handleSelectionChange = useCallback(
@@ -280,7 +341,7 @@ export function PreviewTabs({
 			// Also notify parent
 			onSelectionChange?.(recordIds);
 		},
-		[onSelectionChange]
+		[onSelectionChange],
 	);
 
 	// If parent provided a getter, use ours; otherwise use internal state
@@ -356,12 +417,60 @@ export function PreviewTabs({
 					</MessageBar>
 				</div>
 			)}
+			{editorValidationError && (
+				<div className={styles.messageBarContainer}>
+					<MessageBar intent="error">
+						<MessageBarBody>
+							<MessageBarTitle>Invalid FetchXML</MessageBarTitle>
+							{editorValidationError}
+						</MessageBarBody>
+						<MessageBarActions
+							containerAction={
+								<Button
+									appearance="transparent"
+									icon={<Dismiss16Regular />}
+									onClick={() => setEditorValidationError(null)}
+									aria-label="Dismiss"
+								/>
+							}
+						/>
+					</MessageBar>
+				</div>
+			)}
+			{executeError && (
+				<div className={styles.messageBarContainer}>
+					<MessageBar intent="error">
+						<MessageBarBody>
+							<MessageBarTitle>Execution Failed</MessageBarTitle>
+							{executeError}
+						</MessageBarBody>
+						<MessageBarActions
+							containerAction={
+								<Button
+									appearance="transparent"
+									icon={<Dismiss16Regular />}
+									onClick={onDismissExecuteError}
+									aria-label="Dismiss"
+								/>
+							}
+						/>
+					</MessageBar>
+				</div>
+			)}
 			<div className={styles.tabContent}>
-				{selectedTab === "xml" && (
-					<div className={styles.codeCard}>
-						<FetchXmlEditor xml={xml} onParseToTree={onParseToTree} />
-					</div>
-				)}
+				{/* FetchXML tab — always mounted so Monaco editor state (editor mode, content,
+				    cursor position) survives tab switches. Hidden via display:none when inactive;
+				    Monaco's automaticLayout re-layouts automatically when it becomes visible. */}
+				<div
+					className={styles.codeCard}
+					style={selectedTab !== "xml" ? { display: "none" } : undefined}
+				>
+					<FetchXmlEditor
+						xml={xml}
+						onParseToTree={onParseToTree}
+						onEditorStateChange={handleEditorStateChange}
+					/>
+				</div>
 				{selectedTab === "layout" && (
 					<div className={styles.codeCard}>
 						<LayoutXmlViewer layoutXml={layoutXml || ""} />

--- a/src/features/fetchxml/ui/RightPane/ResultsGrid.tsx
+++ b/src/features/fetchxml/ui/RightPane/ResultsGrid.tsx
@@ -312,7 +312,7 @@ export function ResultsGrid({
 			console.warn("Row without primary ID found - selection may not work correctly");
 			return `row_${Math.random()}`;
 		},
-		[primaryIdColumn]
+		[primaryIdColumn],
 	);
 
 	// Build set of requested attributes from FetchXML query
@@ -414,7 +414,7 @@ export function ResultsGrid({
 		// Collect from link-entities recursively
 		const collectFromLinks = (
 			links: import("../../model/nodes").LinkEntityNode[],
-			parentLookupAttr?: string
+			parentLookupAttr?: string,
 		) => {
 			links.forEach((link) => {
 				const linkAlias = link.alias || link.name;
@@ -464,8 +464,13 @@ export function ResultsGrid({
 
 	// Memoize column definitions with display names and formatted values
 	// Uses columnConfig for ordering and widths when available
-	const columns = useMemo(() => {
-		if (!result || result.columns.length === 0) return [];
+	const { columns, columnDisplayNames, columnAttributeTypes } = useMemo(() => {
+		if (!result || result.columns.length === 0)
+			return {
+				columns: [],
+				columnDisplayNames: new Map<string, string>(),
+				columnAttributeTypes: new Map<string, string | undefined>(),
+			};
 
 		// Filter out OData and CRM annotation columns
 		let displayableColumns = filterDisplayableColumns(result.columns);
@@ -515,14 +520,16 @@ export function ResultsGrid({
 			];
 		}
 
-		return displayableColumns.flatMap((col) => {
+		const displayNames = new Map<string, string>();
+		const attrTypes = new Map<string, string | undefined>();
+		const columnDefs = displayableColumns.flatMap((col) => {
 			// Get column display info from our comprehensive map
 			const displayInfo = columnDisplayMap.get(col);
 
 			// Helper to get attribute metadata from multi-entity map
 			const getAttributeMetadata = (
 				entityName: string,
-				attrName: string
+				attrName: string,
 			): AttributeMetadata | undefined => {
 				return attributeMetadata?.get(entityName)?.get(attrName);
 			};
@@ -633,8 +640,14 @@ export function ResultsGrid({
 					return formattedValue !== undefined && formattedValue !== rawValue;
 				});
 
+			// Track display name and attribute type for column sizing options
+			displayNames.set(col, displayName);
+			attrTypes.set(col, attribute?.AttributeType);
+
 			// For "both" mode with formatted values, create two columns
 			if (valueMode === "both" && hasFormattedValues) {
+				displayNames.set(`${col}__raw`, `${displayName} (Raw)`);
+				attrTypes.set(`${col}__raw`, attribute?.AttributeType);
 				// Create formatted value column
 				const formattedColumn = createTableColumn<Record<string, unknown>>({
 					columnId: col,
@@ -662,7 +675,7 @@ export function ResultsGrid({
 						const rawValue = item[col];
 						const formattedValue = getFormattedValue(item, col);
 						return (
-							<TableCellLayout>
+							<TableCellLayout truncate>
 								{getCellRenderer(attribute?.AttributeType, rawValue, formattedValue, attribute)}
 							</TableCellLayout>
 						);
@@ -685,7 +698,7 @@ export function ResultsGrid({
 					renderCell: (item) => {
 						const rawValue = item[col];
 						return (
-							<TableCellLayout>
+							<TableCellLayout truncate>
 								{rawValue === null || rawValue === undefined ? (
 									<span>—</span>
 								) : (
@@ -730,7 +743,7 @@ export function ResultsGrid({
 					if (valueMode === "raw") {
 						// Show raw value only (skip cell renderer formatting)
 						return (
-							<TableCellLayout>
+							<TableCellLayout truncate>
 								{rawValue === null || rawValue === undefined ? (
 									<span>—</span>
 								) : (
@@ -741,7 +754,7 @@ export function ResultsGrid({
 					} else {
 						// Default: formatted (use cell renderer)
 						return (
-							<TableCellLayout>
+							<TableCellLayout truncate>
 								{getCellRenderer(attribute?.AttributeType, rawValue, formattedValue, attribute)}
 							</TableCellLayout>
 						);
@@ -749,6 +762,11 @@ export function ResultsGrid({
 				},
 			});
 		});
+		return {
+			columns: columnDefs,
+			columnDisplayNames: displayNames,
+			columnAttributeTypes: attrTypes,
+		};
 	}, [
 		result,
 		attributeMetadata,
@@ -770,7 +788,7 @@ export function ResultsGrid({
 			const recordIds = Array.from(data.selectedItems).map(String);
 			onSelectionChange?.(recordIds);
 		},
-		[onSelectedCountChange, onSelectionChange]
+		[onSelectedCountChange, onSelectionChange],
 	);
 
 	// Sort change handler: notifies parent to update FetchXML orders
@@ -779,7 +797,7 @@ export function ResultsGrid({
 	const handleSortChange = useCallback(
 		(
 			e: React.MouseEvent,
-			data: { sortColumn: string | number | undefined; sortDirection: SortDirection }
+			data: { sortColumn: string | number | undefined; sortDirection: SortDirection },
 		) => {
 			if (!onSortChange) return;
 
@@ -806,7 +824,7 @@ export function ResultsGrid({
 				entityName: sortInfo?.entityName,
 			});
 		},
-		[onSortChange, sortStateMap]
+		[onSortChange, sortStateMap],
 	);
 
 	// Row renderer function for virtualization with scrolling indicator support
@@ -826,13 +844,33 @@ export function ResultsGrid({
 				)}
 			</DataGridRow>
 		),
-		[styles.row]
+		[styles.row],
 	);
 
 	// Build column sizing options from columnConfig or defaults
 	const columnSizingOptions = useMemo(() => {
 		const options: Record<string, { minWidth: number; defaultWidth: number; idealWidth?: number }> =
 			{};
+
+		// Minimum width implied by the attribute's data type (data content is often wider than the header)
+		const typeBasedMinWidth = (attrType: string | undefined): number => {
+			switch (attrType) {
+				case "Uniqueidentifier":
+					return 260; // GUIDs: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (36 chars)
+				case "DateTime":
+					return 160; // e.g. "Apr 3, 2026, 09:00 AM"
+				case "Boolean":
+					return 100; // switch + label
+				case "Lookup":
+				case "Customer":
+				case "Owner":
+					return 140; // formatted name, usually a person or account name
+				case "Money":
+					return 120;
+				default:
+					return 100;
+			}
+		};
 
 		// Create a map of column widths from config
 		// Also map lookup field variants (_xxx_value -> config width for xxx)
@@ -846,26 +884,43 @@ export function ResultsGrid({
 		}
 
 		// Set sizing for each column
+		// When no config width is available, estimate from the display name so headers don't overlap
 		for (const col of columns) {
 			const columnId = String(col.columnId);
 			const configWidth = configWidths.get(columnId);
-			const width = configWidth ?? 150; // Default to 150 if not in config
-			options[columnId] = {
-				minWidth: 80,
-				defaultWidth: width,
-				idealWidth: width,
-			};
+
+			if (configWidth !== undefined) {
+				// Use the layout-XML / user-resized width as-is
+				options[columnId] = {
+					minWidth: 80,
+					defaultWidth: configWidth,
+					idealWidth: configWidth,
+				};
+			} else {
+				// No config width – estimate from BOTH header display name and attribute data type.
+				// Take the larger of the two so neither the header nor typical data values overflow.
+				const displayName = columnDisplayNames.get(columnId) ?? columnId;
+				const headerEstimate = Math.ceil(displayName.length * 8) + 52;
+				const dataMin = typeBasedMinWidth(columnAttributeTypes.get(columnId));
+				const estimated = Math.max(headerEstimate, dataMin);
+				const dynamicWidth = Math.max(100, Math.min(estimated, 320));
+				options[columnId] = {
+					minWidth: Math.max(80, Math.min(dataMin, 200)),
+					defaultWidth: dynamicWidth,
+					idealWidth: dynamicWidth,
+				};
+			}
 		}
 
 		return options;
-	}, [columns, columnConfig]);
+	}, [columns, columnConfig, columnDisplayNames, columnAttributeTypes]);
 
 	// Handle column resize callback
 	// Maps lookup column names back to config names for storage
 	const handleColumnResize = useCallback(
 		(
 			_e: KeyboardEvent | TouchEvent | MouseEvent | undefined,
-			data: { columnId: string | number; width: number }
+			data: { columnId: string | number; width: number },
 		) => {
 			if (onColumnResize) {
 				let columnName = String(data.columnId);
@@ -876,7 +931,7 @@ export function ResultsGrid({
 				onColumnResize(columnName, data.width);
 			}
 		},
-		[onColumnResize]
+		[onColumnResize],
 	);
 
 	// Infinite scroll: load more when user scrolls near bottom
@@ -898,7 +953,7 @@ export function ResultsGrid({
 				onLoadMore();
 			}
 		},
-		[result, onLoadMore, isLoadingMore]
+		[result, onLoadMore, isLoadingMore],
 	);
 
 	// Note: Data is already sorted by Dataverse based on FetchXML orders
@@ -957,7 +1012,6 @@ export function ResultsGrid({
 							</DataGridRow>
 						</DataGridHeader>
 						<DataGridBody<Record<string, unknown>>
-							className={styles.body}
 							itemSize={ROW_HEIGHT}
 							height={Math.max(0, gridDimensions.height - headerHeight)}
 							listProps={{


### PR DESCRIPTION
## Results Grid
- Dynamic column width estimation from header text (capped at 400px); adjacent columns no longer overlap on first render
- All cells use TableCellLayout truncate for clean overflow handling
- Remove stray CSS class from DataGridBody that caused header/row width drift when grid content overflowed (misalignment fix)

## Alias Validation
- Add aliasUtils.ts with isValidAlias() and sanitizeAlias() utilities enforcing the Dataverse alias constraint [A-Za-z_][A-Za-z0-9_]*
- AttributeEditor + LinkEntityEditor: sanitize alias in real time on keystroke (strip invalid chars, prefix leading digit with _)
- fetchxmlParser.ts: parseAttribute + parseLinkEntity now import sanitizeAlias; invalid aliases are corrected in place and described in the parse warning (e.g. 'corrected to thisisid') instead of being forwarded as-is to Dataverse where they cause API errors

## FetchXML Editor (editor mode)
- Add Copy button in editor mode toolbar (was missing; only existed in read-only toolbar)
- Validate: fix contradiction where 'Valid' success + warnings appeared simultaneously; now returns early with 'Action required' notice when warnings exist; 'Valid' only shown when warning count is zero
- Parse to Tree: show auto-corrected alias warnings with intent='info' (blue) rather than intent='warning' (yellow) — the tool resolved the problem; no action needed from the user
- Execute in editor mode: block execution when parse warnings exist and surface the warning in a message bar with a hint to use Parse to Tree to auto-correct; previously bad aliases silently reached Dataverse

## PreviewTabs / Tab State Persistence
- FetchXmlEditor is now always mounted; hidden via style={{ display:'none' }} when the FetchXML tab is not active. Previously it was conditionally rendered, which unmounted it on every tab switch — resetting editor mode and discarding the edit buffer.
- handleExecute blocks on parseResult.warnings (not just errors)
- Navigating back to the FetchXML tab clears any stale editor validation error banner

## AppShell
- handleExecute accepts optional xmlOverride for editor mode paths
- executeError state threads Dataverse API errors back to PreviewTabs message bar (previously errors were console-only)
- lastExecutedXmlRef tracks the last XML sent for paging consistency

## Release
- Bump version 1.2.0 → 1.2.1
- CHANGELOG.md: add [1.2.1] section
- README.md: update version badge; clarify Copy available in both modes; add alias validation mention in FetchXML Editor feature list

## Summary

What does this PR change and why?

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build/CI

## How to test

Steps to validate the change.

## Screenshots (if UI)

Before/After images or recordings.

## Checklist

- [ ] Added/updated tests (if applicable)
- [ ] Updated docs (if applicable)
- [x] No secrets included (tokens/keys)
- [ ] Accessibility considered (keyboard/nav/contrast)
